### PR TITLE
Set locale to C.UTF-8 in Dockerfile

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -40,3 +40,7 @@ RUN echo "576562626572264761624c65526f7578" > /etc/machine-id && mkdir -p /var/l
 
 # Used by Unity editor in "modules.json" and must not end with a slash.
 ENV UNITY_PATH="/opt/unity"
+
+# Fixes a Gradle crash while building for Android on Unity 2019 when there are accented characters in environment variables
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8


### PR DESCRIPTION
#### Changes

- Sets the locale to C.UTF-8 in Dockerfile
- This fixes a Gradle crash while building for Android on Unity 2019 when there are accented characters in the environment variables

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme not needed
- [x] Tests not needed (I think?)

#### Rationale

As discussed with @webbertakken on Discord

Relates to https://github.com/gradle/gradle/issues/3117
The issue is fixed in Gradle 5.3, but it seems Unity 2019 ships with an older version