### PR TITLE
fix: add extra dependencies for 2019.1

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -53,3 +53,15 @@ RUN [ `echo $module | grep -v '\(webgl\|linux-il2cpp\)'` ] && exit 0 || : \
     clang \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+#=======================================================================================
+# [2019.1.x] libnotify4 libunwind-dev libssl1.0
+#=======================================================================================
+RUN [ `echo $version | grep -v '^2019.1.'` ] && exit 0 || : \
+  && apt-get -q update \
+  && apt-get -q install -y --no-install-recommends --allow-downgrades \
+    libnotify4 \
+    libunwind-dev \
+    libssl1.0  \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
#### Changes

- Fix #57 
- Add dependencies for 2019.1
  - libnotify4
  - libunwind-dev
  - libssl1.0

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)

#### Versions and modules to be fixed

Tested with #60 (in my repo)

| Module | Fixed? |
| -- | -- |
| Base<br>(Linux-Mono) | :x: -> ✅  |
| Windows-Mono | :x: -> ✅  |
| Mac-Mono | :x: -> ✅  |
| Android | :x: -> ✅  |
| iOS | :x: -> ✅  |
| WebGL | :x: -> ✅  |
| Linux-IL2CPP | :x: -> ✅ <br>(with #61)  |

#### Increased image size

About 10 MB.

```
REPOSITORY   TAG       IMAGE ID       CREATED              SIZE
editor       before    e0a43d920df0   About a minute ago   4.02GB
editor       after     bf3c52bbd759   1 second ago         4.03GB
```

Test:

```dockerfile
FROM unityci/editor:2019.1.14f1-base-0

RUN apt-get -q update \
  && apt-get -q install -y --no-install-recommends --allow-downgrades \
    libnotify4 \
    libunwind-dev \
    libssl1.0  \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
```