### PR TITLE
fix: add extra dependencies for webgl and il2cpp

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -28,6 +28,7 @@ FROM $baseImage
 
 # Always put "Editor" and "modules.json" directly in $UNITY_PATH
 ARG version
+ARG module
 COPY --from=builder /opt/unity/editors/$version/ "$UNITY_PATH/"
 
 # Add a file containing the version for this build
@@ -36,3 +37,19 @@ RUN echo $version > "$UNITY_PATH/version"
 # Alias to "unity-editor" with default params
 RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"' > /usr/bin/unity-editor \
  && chmod +x /usr/bin/unity-editor
+
+###########################
+#       Extra steps       #
+###########################
+
+#=======================================================================================
+# [webgl, il2cpp] python build-essential clang
+#=======================================================================================
+RUN [ `echo $module | grep -v '\(webgl\|linux-il2cpp\)'` ] && exit 0 || : \
+  && apt-get -q update \
+  && apt-get -q install -y --no-install-recommends --allow-downgrades \
+    python \
+    build-essential \
+    clang \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
#### Changes

- Fix #53 
- Add dependencies for `webgl` and `linux-il2cpp`
  - python
  - build-essential
  - clang
 
#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)

#### Versions and modules to be fixed

Tested with #60 (in my repo)

| version | WebGL | IL2CPP |
| -- | -- | -- |
| 2018.3.x | ✅  | ✅ |
| 2018.4.x | ✅  | ✅ |
| 2019.1.x | ✅ <br>(With #59) | ✅ |
| 2019.2.x | ✅  | ✅ |
| 2019.3.x | ✅  | ❌ |
| 2019.4.x | ✅  | ✅ |
| 2020.1.x | ✅  | ✅ |
| 2020.2.x | ✅  | ✅ |
| 2021.1.x | ✅  | ❌ |