### PR TITLE
fix: add `IL2CPP_ADDITIONAL_ARGS` for 2019.3.x-linux-il2cpp

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -53,3 +53,15 @@ RUN [ `echo $module | grep -v '\(webgl\|linux-il2cpp\)'` ] && exit 0 || : \
     clang \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+#=======================================================================================
+# [2019.3.x-linux-il2cpp] IL2CPP_ADDITIONAL_ARGS='--sysroot-path=/ --tool-chain-path=/'
+# https://forum.unity.com/threads/unity-2019-3-linux-il2cpp-player-can-only-be-built-with-linux-error.822210/#post-5633977
+#=======================================================================================
+RUN [ `echo $version-$module | grep -v '^2019.3.*-linux-il2cpp'` ] && exit 0 || : \
+  && { \
+    echo '#!/bin/bash'; \
+    echo 'export IL2CPP_ADDITIONAL_ARGS="--sysroot-path=/ --tool-chain-path=/"'; \
+    echo 'xvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"'; \
+  } > /usr/bin/unity-editor \
+  && chmod +x /usr/bin/unity-editor

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -35,8 +35,18 @@ COPY --from=builder /opt/unity/editors/$version/ "$UNITY_PATH/"
 RUN echo $version > "$UNITY_PATH/version"
 
 # Alias to "unity-editor" with default params
-RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"' > /usr/bin/unity-editor \
- && chmod +x /usr/bin/unity-editor
+RUN { \
+    echo '#!/bin/bash'; \
+    echo ''; \
+    \
+    [ `echo $version-$module | grep -e '^2019.3.*-linux-il2cpp'` ] \
+        && echo '# [2019.3.x-linux-il2cpp] https://forum.unity.com/threads/unity-2019-3-linux-il2cpp-player-can-only-be-built-with-linux-error.822210/#post-5633977' \
+        && echo 'export IL2CPP_ADDITIONAL_ARGS="--sysroot-path=/ --tool-chain-path=/"' \
+        && echo ''; \
+    \
+    echo 'xvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"'; \
+  } > /usr/bin/unity-editor \
+  && chmod +x /usr/bin/unity-editor
 
 ###########################
 #       Extra steps       #
@@ -53,15 +63,3 @@ RUN [ `echo $module | grep -v '\(webgl\|linux-il2cpp\)'` ] && exit 0 || : \
     clang \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-
-#=======================================================================================
-# [2019.3.x-linux-il2cpp] IL2CPP_ADDITIONAL_ARGS='--sysroot-path=/ --tool-chain-path=/'
-# https://forum.unity.com/threads/unity-2019-3-linux-il2cpp-player-can-only-be-built-with-linux-error.822210/#post-5633977
-#=======================================================================================
-RUN [ `echo $version-$module | grep -v '^2019.3.*-linux-il2cpp'` ] && exit 0 || : \
-  && { \
-    echo '#!/bin/bash'; \
-    echo 'export IL2CPP_ADDITIONAL_ARGS="--sysroot-path=/ --tool-chain-path=/"'; \
-    echo 'xvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"'; \
-  } > /usr/bin/unity-editor \
-  && chmod +x /usr/bin/unity-editor


### PR DESCRIPTION
#### Changes

- Fix #62 
- Add environment variable `IL2CPP_ADDITIONAL_ARGS="--sysroot-path=/ --tool-chain-path=/"`.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)

#### Versions and modules to be fixed

Tested with #60 (in my repo)

| Module | Fixed? |
| -- | -- |
| Linux-IL2CPP | :x: -> ✅ |

#### Increased image size

< 1 KB