### PR TITLE
fix: do not test for il2cpp that does not exist in 2019.2 or earlier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
           echo "CHANGESET=`npx unity-changeset ${{ matrix.version }}`" >> $GITHUB_ENV
 
           # For 2019.3 or later, non-il2cpp would also be possible to build with il2cpp image.
-          if [ `echo "${{ matrix.version }}" | grep -v '\(2018|2019.1|2019.2\)'` ] && [ "${{ matrix.module }}" = 'base' ] ; then
+          if [ `echo "${{ matrix.version }}" | grep -v '\(2018\|2019.1\|2019.2\)'` ] && [ "${{ matrix.module }}" = 'base' ] ; then
             echo "MODULE=linux-il2cpp" >> $GITHUB_ENV
           else
             echo "MODULE=${{ matrix.module }}" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: base-and-hub.tar
+          retention-days: 1
 
       ###########################
       #    Setup build matrix   #


### PR DESCRIPTION
#### Changes

- fix grep command to check Unity version (2019.3 or later)
- For 2019.2 or earlier, use `base` image to test

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
