### PR TITLE
enable pr target in workflow

### DIFF
--- a/.github/workflows/cats.yml
+++ b/.github/workflows/cats.yml
@@ -1,7 +1,7 @@
 name: Cats 😺
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
 name: Docs 📚
 
 on:
-  pull_request: {}
   push: { branches: [main] }
 
 jobs:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,7 +1,7 @@
 name: PR 😎
 
 on:
-  pull_request: {}
+  pull_request_target: {}
 
 jobs:
   reportingTest:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - "**/Dockerfile"
       - .github/workflows/test.yml
       - reference-project-test/*
-  pull_request:
+  pull_request_target:
     paths:
       - "**/Dockerfile"
       - .github/workflows/test.yml


### PR DESCRIPTION
#### Changes

- This changes PR workflows to use `pull_request_target` (see [here](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) instead of `pull_request` as a solution to secrets not being accessible by PRs from forks.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
