### PR TITLE
Add support android for Unity 2019.2 or earlier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,9 +89,6 @@ jobs:
           # Exclude linux-il2cpp for Unity 2019.2 or earlier
           EXCLUDES="$EXCLUDES `echo \"$VERSIONS\" | jq -c '[ .[] | select(test(\"2018|2019.1|2019.2\")) | { version: ., module: \"linux-il2cpp\"} ]'`"
 
-          # Exclude android for Unity 2019.2 or earlier
-          EXCLUDES="$EXCLUDES `echo \"$VERSIONS\" | jq -c '[ .[] | select(test(\"2018|2019.1|2019.2\")) | { version: ., module: \"android\"} ]'`"
-
           EXCLUDES=`echo "$EXCLUDES" | jq -s -c 'flatten'`
           echo "Excludes: $EXCLUDES"
           echo "::set-output name=excludes::$EXCLUDES"

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -53,6 +53,60 @@ RUN { \
 ###########################
 
 #=======================================================================================
+# [2018.x-android] Install 'Android SDK 26.1.1' and 'Android NDK 16.1.4479499'
+#=======================================================================================
+RUN [ `echo $version-$module | grep -v '^2018.*-android'` ] && exit 0 || : \
+  \
+  # Versions
+  && export ANDROID_BUILD_TOOLS_VERSION=28.0.3 \
+  && export ANDROID_NDK_VERSION=16.1.4479499 \
+  \
+  # Environment Variables
+  && export ANDROID_INSTALL_LOCATION=${UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer \
+  && export ANDROID_SDK_ROOT=${ANDROID_INSTALL_LOCATION}/SDK \
+  && export ANDROID_HOME=${ANDROID_SDK_ROOT} \
+  && export ANDROID_NDK_HOME=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION} \
+  && export JAVA_HOME=${UNITY_PATH}/Editor/Data/PlaybackEngines/AndroidPlayer/Tools/OpenJDK/Linux \
+  && export PATH=$JAVA_HOME/bin:${ANDROID_SDK_ROOT}/tools:${ANDROID_SDK_ROOT}/tools/bin:${ANDROID_SDK_ROOT}/platform-tools:${PATH} \
+  \
+  # Download Android SDK (commandline tools) 26.1.1
+  && apt-get update -qq \
+  && apt-get install -qq -y --no-install-recommends unzip \
+  && mkdir -p ${ANDROID_SDK_ROOT} \
+  && chown -R 777 ${ANDROID_INSTALL_LOCATION} \
+  && wget -q https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -O /tmp/android-sdk.zip \
+  && unzip -q /tmp/android-sdk.zip -d ${ANDROID_SDK_ROOT} \
+  \
+  # Install platform-tools, NDK 16.1.4479499 and build-tools 28.0.3
+  && yes | sdkmanager \
+    "platform-tools" \
+    "ndk;${ANDROID_NDK_VERSION}" \
+    "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
+    > /dev/null \
+  \
+  # Accept licenses
+  && yes | sdkmanager --licenses \
+  \
+  # Clean up
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /tmp/* \
+  \
+  # Update alias 'unity-editor'
+  && { \
+    echo '#!/bin/bash'; \
+    echo ''; \
+    echo "export ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT}"; \
+    echo "export ANDROID_HOME=${ANDROID_HOME}"; \
+    echo "export ANDROID_NDK_HOME=${ANDROID_NDK_HOME}"; \
+    echo "export JAVA_HOME=${JAVA_HOME}"; \
+    echo "export PATH=${PATH}"; \
+    echo ''; \
+    echo 'xvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"'; \
+  } > /usr/bin/unity-editor \
+  && chmod +x /usr/bin/unity-editor
+
+#=======================================================================================
 # [webgl, il2cpp] python build-essential clang
 #=======================================================================================
 RUN [ `echo $module | grep -v '\(webgl\|linux-il2cpp\)'` ] && exit 0 || : \

--- a/reference-project-test/ProjectSettings/ProjectSettings.asset
+++ b/reference-project-test/ProjectSettings/ProjectSettings.asset
@@ -12,7 +12,7 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: Coffee
+  companyName: GameCI
   productName: BuildTest
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
@@ -153,7 +153,7 @@ PlayerSettings:
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
-    Android: com.coffee.buildtest
+    Android: com.gameci.buildtest
   buildNumber: {}
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 16
@@ -498,7 +498,9 @@ PlayerSettings:
   webGLThreadsSupport: 0
   scriptingDefineSymbols: {}
   platformArchitecture: {}
-  scriptingBackend: {}
+  scriptingBackend:
+    Standalone: 0
+    Android: 1
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}

--- a/reference-project-test/ProjectSettings/ProjectSettings_il2cpp.asset
+++ b/reference-project-test/ProjectSettings/ProjectSettings_il2cpp.asset
@@ -12,7 +12,7 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: DefaultCompany
+  companyName: GameCI
   productName: BuildTest
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
@@ -152,7 +152,8 @@ PlayerSettings:
   resolutionScalingMode: 0
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
-  applicationIdentifier: {}
+  applicationIdentifier:
+    Android: com.gameci.buildtest
   buildNumber: {}
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 16
@@ -492,13 +493,14 @@ PlayerSettings:
   webGLTemplate: APPLICATION:Default
   webGLAnalyzeBuildSize: 0
   webGLUseEmbeddedResources: 0
-  webGLCompressionFormat: 1
+  webGLCompressionFormat: 2
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0
   scriptingDefineSymbols: {}
   platformArchitecture: {}
   scriptingBackend:
     Standalone: 1
+    Android: 1
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}


### PR DESCRIPTION
See #68 

#### Changes

- Install `Android SDK 26.1.1` and `Android NDK 16.1.4479499` 
- Add environment variables to `unity-editor`
- Add test that contains IL2CPP test
- Tested on my repo: https://github.com/mob-sakai/docker/actions/runs/507500382
  -  It contains an timeout error, but it is not related to this PR

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
