### PR TITLE
Fix GZip/Brotli compression for webgl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -225,6 +225,40 @@ jobs:
           allowDirtyBuild: true
 
       ###########################
+      #       Build (GZip)      #
+      ###########################
+      - name: "⚙️ Setup (GZip)"
+        if: env.MODULE == 'webgl'
+        run: |
+          sed -i -e 's/webGLCompressionFormat: .*$/webGLCompressionFormat: 1/' reference-project-test/ProjectSettings/ProjectSettings.asset
+      - name: Build project (GZip)
+        if: env.MODULE == 'webgl'
+        uses: game-ci/unity-builder@main
+        with:
+          unityVersion: ${{ matrix.version }}
+          customImage: editor:dev
+          projectPath: reference-project-test
+          targetPlatform: ${{ matrix.platform }}
+          allowDirtyBuild: true
+
+      ###########################
+      #       Build (Brotli)      #
+      ###########################
+      - name: "⚙️ Setup (Brotli)"
+        if: env.MODULE == 'webgl'
+        run: |
+          sed -i -e 's/webGLCompressionFormat: .*$/webGLCompressionFormat: 0/' reference-project-test/ProjectSettings/ProjectSettings.asset
+      - name: Build project (Brotli)
+        if: env.MODULE == 'webgl'
+        uses: game-ci/unity-builder@main
+        with:
+          unityVersion: ${{ matrix.version }}
+          customImage: editor:dev
+          projectPath: reference-project-test
+          targetPlatform: ${{ matrix.platform }}
+          allowDirtyBuild: true
+
+      ###########################
       #           Test          #
       ###########################
       - name: Test project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,6 +230,7 @@ jobs:
       - name: "⚙️ Setup (GZip)"
         if: env.MODULE == 'webgl'
         run: |
+          # Set WebGL compression format to gzip
           sed -i -e 's/webGLCompressionFormat: .*$/webGLCompressionFormat: 1/' reference-project-test/ProjectSettings/ProjectSettings.asset
       - name: Build project (GZip)
         if: env.MODULE == 'webgl'
@@ -247,6 +248,7 @@ jobs:
       - name: "⚙️ Setup (Brotli)"
         if: env.MODULE == 'webgl'
         run: |
+          # Set WebGL compression format to brotli
           sed -i -e 's/webGLCompressionFormat: .*$/webGLCompressionFormat: 0/' reference-project-test/ProjectSettings/ProjectSettings.asset
       - name: Build project (Brotli)
         if: env.MODULE == 'webgl'

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -44,6 +44,11 @@ RUN { \
         && echo 'export IL2CPP_ADDITIONAL_ARGS="--sysroot-path=/ --tool-chain-path=/"' \
         && echo ''; \
     \
+    [ `echo $version-$module | grep -e '^\(2020.1\|2020.2.0\|2020.2.1\).*-webgl'` ] \
+        && echo '# [2020.x/2020.2.0/2020.2.1-webgl] Support GZip compression: https://github.com/game-ci/docker/issues/75' \
+        && echo 'export GZIP=-f' \
+        && echo ''; \
+    \
     echo 'xvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"'; \
   } > /usr/bin/unity-editor \
   && chmod +x /usr/bin/unity-editor

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -112,12 +112,13 @@ RUN [ `echo $version-$module | grep -v '^2018.*-android'` ] && exit 0 || : \
   && chmod +x /usr/bin/unity-editor
 
 #=======================================================================================
-# [webgl, il2cpp] python build-essential clang
+# [webgl, il2cpp] python python-setuptools build-essential clang
 #=======================================================================================
 RUN [ `echo $module | grep -v '\(webgl\|linux-il2cpp\)'` ] && exit 0 || : \
   && apt-get -q update \
   && apt-get -q install -y --no-install-recommends --allow-downgrades \
     python \
+    python-setuptools \
     build-essential \
     clang \
   && apt-get clean \
@@ -134,3 +135,11 @@ RUN [ `echo $version | grep -v '^2019.1.'` ] && exit 0 || : \
     libssl1.0  \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+#=======================================================================================
+# [2018.x/2019.x/2020.1.x-webgl] support brotli compression for linux
+#=======================================================================================
+RUN [ `echo $version-$module | grep -v '^\(2018\|2019\|2020.1\).*-webgl'` ] && exit 0 || : \
+  && cp \
+    $UNITY_PATH/Editor/Data/PlaybackEngines/WebGLSupport/BuildTools/Brotli/dist/Brotli-0.4.0-py2.7-linux-x86_64.egg \
+    $UNITY_PATH/Editor/Data/PlaybackEngines/WebGLSupport/BuildTools/Brotli/dist/Brotli-0.4.0-py2.7-macosx-10.10-x86_64.egg


### PR DESCRIPTION
#### Changes

See #75

- Add GZip/Brotli compression tests for webgl module
- Support GZip compression for webgl (for 2020.x, 2020.2.0 and 2020.2.1)
  - Add -f as default option for gzip
- Support Brotli compression for webgl (for 2018.x, 2019.x and 2020.1.x)
  - Install `python-setuptools`
  - Copy brotli egg for linux

```
REPOSITORY       TAG                   IMAGE ID       CREATED          SIZE
unityci/editor   dev                   ed64129acfe7   49 seconds ago   6.21GB
unityci/editor   2020.1.11f1-webgl-0   e10428a15532   5 days ago       6.2GB
```

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)

#### Test

- Before modification: https://github.com/mob-sakai/docker/actions/runs/565959178
  - NOTE: In Unity 2018.4.15 or earlier, even if brotli compression fails, the build will be marked as successful.
- After modification: https://github.com/game-ci/docker/actions/runs/566007780