### PR TITLE
Retry publication before reporting build as failure.

### DIFF
--- a/.github/workflows/new-legacy-editor-image-requested.yml
+++ b/.github/workflows/new-legacy-editor-image-requested.yml
@@ -123,6 +123,37 @@ jobs:
             unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
           ### Warning: If we once publish latest, we will have to do it forever. Lets not do that unless it's needed ###
           ### Another warning: order is important: We go from specific to unspecific with the exception of the most specific tag which is used to check if the image is already there ###
+      ###########################
+      #     Retry the above     #
+      ###########################
+      - name: Build and publish (retry)
+        uses: docker/build-push-action@v2
+        if: steps.build_editor_image.outcome=='failure'
+        id: build_editor_image_retry
+        with:
+          context: .
+          file: ./editor/Dockerfile
+          build-args: |
+            hubImage=unityci/hub:${{ github.event.client_payload.repoVersionFull }}
+            baseImage=unityci/base:${{ github.event.client_payload.repoVersionFull }}
+            version=${{ github.event.client_payload.editorVersion }}
+            changeSet=${{ github.event.client_payload.changeSet }}
+            module=${{ matrix.targetPlatform }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          push: true
+          tags: |
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionMinor }}
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionMinor }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionMajor }}
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionMajor }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
+          ### Warning: If we once publish latest, we will have to do it forever. Lets not do that unless it's needed ###
+          ### Another warning: order is important: We go from specific to unspecific with the exception of the most specific tag which is used to check if the image is already there ###
+      ###########################
+      #   Inspect publication   #
+      ###########################
       - name: Inspect
         run: |
           docker buildx imagetools inspect unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}

--- a/.github/workflows/new-post-2019-2-editor-image-requested.yml
+++ b/.github/workflows/new-post-2019-2-editor-image-requested.yml
@@ -123,6 +123,37 @@ jobs:
             unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
           ### Warning: If we once publish latest, we will have to do it forever. Lets not do that unless it's needed ###
           ### Another warning: order is important: We go from specific to unspecific with the exception of the most specific tag which is used to check if the image is already there ###
+      ###########################
+      #     Retry the above     #
+      ###########################
+      - name: Build and publish (retry)
+        uses: docker/build-push-action@v2
+        if: steps.build_editor_image.outcome=='failure'
+        id: build_editor_image_retry
+        with:
+          context: .
+          file: ./editor/Dockerfile
+          build-args: |
+            hubImage=unityci/hub:${{ github.event.client_payload.repoVersionFull }}
+            baseImage=unityci/base:${{ github.event.client_payload.repoVersionFull }}
+            version=${{ github.event.client_payload.editorVersion }}
+            changeSet=${{ github.event.client_payload.changeSet }}
+            module=${{ matrix.targetPlatform }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          push: true
+          tags: |
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionMinor }}
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionMinor }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionMajor }}
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionMajor }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
+          ### Warning: If we once publish latest, we will have to do it forever. Lets not do that unless it's needed ###
+          ### Another warning: order is important: We go from specific to unspecific with the exception of the most specific tag which is used to check if the image is already there ###
+      ###########################
+      #   Inspect publication   #
+      ###########################
       - name: Inspect
         run: |
           docker buildx imagetools inspect unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}

--- a/.github/workflows/retry-editor-image-requested.yml
+++ b/.github/workflows/retry-editor-image-requested.yml
@@ -112,6 +112,36 @@ jobs:
             unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
           ### Warning: If we once publish latest, we will have to do it forever. Lets not do that unless it's needed ###
           ### Another warning: order is important: We go from specific to unspecific with the exception of the most specific tag which is used to check if the image is already there ###
+      ###########################
+      #     Retry the above     #
+      ###########################
+      - name: Build and publish (retry)
+        uses: docker/build-push-action@v2
+        if: steps.build_editor_image.outcome=='failure'
+        id: build_editor_image_retry
+        with:
+          context: .
+          file: ./editor/Dockerfile
+          build-args: |
+            hubImage=unityci/hub:${{ github.event.client_payload.repoVersionFull }}
+            baseImage=unityci/base:${{ github.event.client_payload.repoVersionFull }}
+            version=${{ github.event.client_payload.editorVersion }}
+            changeSet=${{ github.event.client_payload.changeSet }}
+            module=${{ github.event.client_payload.targetPlatform }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          push: true
+          tags: |
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionMinor }}
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionMinor }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionMajor }}
+            unityci/editor:${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionMajor }}
+            unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
+          ### Warning: If we once publish latest, we will have to do it forever. Lets not do that unless it's needed ###
+          ### Another warning: order is important: We go from specific to unspecific with the exception of the most specific tag which is used to check if the image is already there ###
+      ###########################
+      #   Inspect publication   #
+      ###########################
       - name: Inspect
         run: |
           docker buildx imagetools inspect unityci/editor:ubuntu-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}


### PR DESCRIPTION
#### Changes

- This duplicates build and publish step, executed only when it fails initially.
- I expect that 90% or more of the failures should be mitigated in this way, in particular:
    - Failure during the build phase, where some dependency download isn't received properly
    - Connection interrupted while pushing the image to dockerhub
    - Failure with one of the calls to apply one of the tags


#### Considered alternatives

- Added this use case as rationale to github community [thread](https://github.community/t/retry-for-failed-steps/17136?u=webbertakken) about retrying steps. Ideally we'd just set the step to retry up to 2 times instead of duplicating all this code.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
