### PR TITLE
refactor: alias to unity-editor

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -34,26 +34,34 @@ COPY --from=builder /opt/unity/editors/$version/ "$UNITY_PATH/"
 # Add a file containing the version for this build
 RUN echo $version > "$UNITY_PATH/version"
 
-# Alias to "unity-editor" with default params
-RUN { \
-    echo '#!/bin/bash'; \
-    echo ''; \
-    \
-    [ `echo $version-$module | grep -e '^\(2019.3\|2019.4.0\).*-linux-il2cpp'` ] \
-        && echo '# [2019.3.x/2019.4.0-linux-il2cpp] https://forum.unity.com/threads/unity-2019-3-linux-il2cpp-player-can-only-be-built-with-linux-error.822210/#post-5633977' \
-        && [ `echo $version | grep -e '2019.3.[0-5]f'` ] \
-          && echo 'export IL2CPP_ADDITIONAL_ARGS="--tool-chain-path=/"' \
-          || echo 'export IL2CPP_ADDITIONAL_ARGS="--sysroot-path=/ --tool-chain-path=/"' \
-        && echo ''; \
-    \
-    [ `echo $version-$module | grep -e '^\(2020.1\|2020.2.0\|2020.2.1\).*-webgl'` ] \
-        && echo '# [2020.x/2020.2.0/2020.2.1-webgl] Support GZip compression: https://github.com/game-ci/docker/issues/75' \
-        && echo 'export GZIP=-f' \
-        && echo ''; \
-    \
-    echo 'xvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"'; \
-  } > /usr/bin/unity-editor \
+
+###########################
+#  Alias to unity-editor  #
+###########################
+
+RUN echo '#!/bin/bash' > /usr/bin/unity-editor \
   && chmod +x /usr/bin/unity-editor
+
+#=======================================================================================
+# [2019.3.[0-5]-linux-il2cpp] https://github.com/game-ci/docker/issues/76
+#=======================================================================================
+RUN [ `echo $version-$module | grep -v '^2019.3.[0-5]f.*-linux-il2cpp'` ] && exit 0 || : \
+  && echo 'export IL2CPP_ADDITIONAL_ARGS=--tool-chain-path=/' >> /usr/bin/unity-editor
+
+#=======================================================================================
+# [2019.3.6+/2019.4.0-linux-il2cpp] https://forum.unity.com/threads/unity-2019-3-linux-il2cpp-player-can-only-be-built-with-linux-error.822210/#post-5633977
+#=======================================================================================
+RUN [ `echo $version-$module | grep -v '^\(2019.3.[6-9]f\|2019.3.1[0-9]f\|2019.4.0\).*-linux-il2cpp'` ] && exit 0 || : \
+  && echo 'export IL2CPP_ADDITIONAL_ARGS="--sysroot-path=/ --tool-chain-path=/"' >> /usr/bin/unity-editor
+
+#=======================================================================================
+# [2020.x/2020.2.0/2020.2.1-webgl] Support GZip compression: https://github.com/game-ci/docker/issues/75
+#=======================================================================================
+RUN [ `echo $version-$module | grep -v '^\(2020.1\|2020.2.0f\|2020.2.1f\).*-webgl'` ] && exit 0 || : \
+  && echo 'export GZIP=-f' >> /usr/bin/unity-editor
+
+RUN echo 'xvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"' >> /usr/bin/unity-editor
+
 
 ###########################
 #       Extra steps       #


### PR DESCRIPTION
See #78

#### Changes

- [The modification to `/usr/bin/unity-editor` is particularly complex](https://github.com/game-ci/docker/blob/main/editor/Dockerfile#L37-L56).
  - Improve readability.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
