### PR TITLE
Fix build process for 2018.2 and below

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -70,7 +70,7 @@ RUN echo 'xvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"' >
 #=======================================================================================
 # [2018.x-android] Install 'Android SDK 26.1.1' and 'Android NDK 16.1.4479499'
 #=======================================================================================
-RUN [ `echo $version-$module | grep -v '^2018.*-android'` ] && exit 0 || : \
+RUN [ `echo $version-$module | grep -v '^\(2018.3\|2018.4\).*-android'` ] && exit 0 || : \
   \
   # Versions
   && export ANDROID_BUILD_TOOLS_VERSION=28.0.3 \


### PR DESCRIPTION
#### Changes

- Fixes build process for 2018.2 and 2018.1, where `sdkmanager` is not present.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
