### PR TITLE
Add ffmpeg in webgl editor

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -155,6 +155,16 @@ RUN [ `echo $version-$module | grep -v '^20(?!18).*-android'` ] && exit 0 || : \
   } > ~/.bashrc
 
 #=======================================================================================
+# [webgl] Support audio using ffmpeg (~99MB)
+#=======================================================================================
+RUN [ `echo $module | grep -v 'webgl'` ] && exit 0 || : \
+  && apt-get update \
+  && apt-get -q install -y --no-install-recommends --allow-downgrades \
+    ffmpeg \
+  && apt-get clean
+  && rm -rf /var/lib/apt/lists/*
+
+#=======================================================================================
 # [webgl, il2cpp] python python-setuptools build-essential clang
 #=======================================================================================
 RUN [ `echo $module | grep -v '\(webgl\|linux-il2cpp\)'` ] && exit 0 || : \

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -161,7 +161,7 @@ RUN [ `echo $module | grep -v 'webgl'` ] && exit 0 || : \
   && apt-get update \
   && apt-get -q install -y --no-install-recommends --allow-downgrades \
     ffmpeg \
-  && apt-get clean
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 #=======================================================================================


### PR DESCRIPTION
#### Changes

- This adds ffmpeg in webgl builds of the editor image.
- Closes https://github.com/game-ci/unity-builder/issues/223

#### Pending:

- [x] Confirmation that this is WebGL only
- [x] Confirmation that recommends are not necessary

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [X] Readme (updated or not needed)
