### PR TITLE
Use full path sdkmanager for all android images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         id: setup
         run: |
           # Get the Unity versions for test. (The latest patch versions for each minor version.)
-          VERSIONS=`npx unity-changeset list --versions --latest-patch --json --min 2018.3`
+          VERSIONS=`npx unity-changeset list --versions --latest-patch --json --min 2018.1`
           echo "Versions: $VERSIONS"
           echo "::set-output name=versions::$VERSIONS"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         id: setup
         run: |
           # Get the Unity versions for test. (The latest patch versions for each minor version.)
-          VERSIONS=`npx unity-changeset list --versions --latest-patch --json --min 2018.1`
+          VERSIONS=`npx unity-changeset list --versions --latest-patch --json --min 2018.3`
           echo "Versions: $VERSIONS"
           echo "::set-output name=versions::$VERSIONS"
 

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -70,7 +70,7 @@ RUN echo 'xvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"' >
 #=======================================================================================
 # [2018.x-android] Install 'Android SDK 26.1.1' and 'Android NDK 16.1.4479499'
 #=======================================================================================
-RUN [ `echo $version-$module | grep -v '^2018.*-android'` ] && exit 0 || : \
+RUN [ `echo $version-$module | grep -v '^\(2018.3\|2018.4\).*-android'` ] && exit 0 || : \
   \
   # Versions
   && export ANDROID_BUILD_TOOLS_VERSION=28.0.3 \

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -70,7 +70,7 @@ RUN echo 'xvfb-run -ae /dev/stdout "$UNITY_PATH/Editor/Unity" -batchmode "$@"' >
 #=======================================================================================
 # [2018.x-android] Install 'Android SDK 26.1.1' and 'Android NDK 16.1.4479499'
 #=======================================================================================
-RUN [ `echo $version-$module | grep -v '^\(2018.3\|2018.4\).*-android'` ] && exit 0 || : \
+RUN [ `echo $version-$module | grep -v '^2018.*-android'` ] && exit 0 || : \
   \
   # Versions
   && export ANDROID_BUILD_TOOLS_VERSION=28.0.3 \
@@ -100,7 +100,7 @@ RUN [ `echo $version-$module | grep -v '^\(2018.3\|2018.4\).*-android'` ] && exi
     > /dev/null \
   \
   # Accept licenses
-  && yes | sdkmanager --licenses \
+  && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \
   \
   # Clean up
   && apt-get clean \
@@ -134,6 +134,11 @@ RUN [ `echo $version-$module | grep -v '^20(?!18).*-android'` ] && exit 0 || : \
   && export RAW_JAVA_HOME=$(jq -cr '(.[] | select(.id == "android-open-jdk")).destination' $UNITY_PATH/modules.json) \
   && export JAVA_HOME=${RAW_JAVA_HOME/'{UNITY_PATH}'/$UNITY_PATH} \
   && export PATH=$JAVA_HOME/bin:${ANDROID_SDK_ROOT}/tools:${ANDROID_SDK_ROOT}/tools/bin:${ANDROID_SDK_ROOT}/platform-tools:${PATH} \
+  \
+  # Accept licenses
+  && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \
+  \
+  # Update alias 'unity-editor'
   && { \
     echo '#!/bin/bash'; \
     echo ''; \


### PR DESCRIPTION
#### Changes

- Use full path sdkmanager to accept licenses
- Re-enables 2018.2 and below
- Closes https://github.com/game-ci/docker/issues/84

#### Pending

- [ ] Confirmation that 2018.2 and 2018.1 builds are indeed fixed by this

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
