### PR TITLE
fix: remove cache for building editor image

### DIFF
--- a/.github/workflows/new-legacy-editor-image-requested.yml
+++ b/.github/workflows/new-legacy-editor-image-requested.yml
@@ -74,16 +74,6 @@ jobs:
             echo "Image already exists. Exiting."
             exit 1
           fi
-      - name: Cache Docker layers
-        uses: actions/cache@v2.1.4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.sha }}
-          restore-keys: |
-            ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-
-            ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-
-            ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-editor-
-            ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-
       ###########################
       #    Free disk space   #
       ###########################

--- a/.github/workflows/new-post-2019-2-editor-image-requested.yml
+++ b/.github/workflows/new-post-2019-2-editor-image-requested.yml
@@ -74,16 +74,6 @@ jobs:
             echo "Image already exists. Exiting."
             exit 1
           fi
-      - name: Cache Docker layers
-        uses: actions/cache@v2.1.4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.sha }}
-          restore-keys: |
-            ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-
-            ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-
-            ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-editor-
-            ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-
       ###########################
       #    Free disk space   #
       ###########################

--- a/.github/workflows/retry-editor-image-requested.yml
+++ b/.github/workflows/retry-editor-image-requested.yml
@@ -64,16 +64,6 @@ jobs:
             echo "Image already exists. Exiting."
             exit 1
           fi
-      - name: Cache Docker layers
-        uses: actions/cache@v2.1.4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.sha }}
-          restore-keys: |
-            ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-
-            ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-editor-${{ github.event.client_payload.editorVersion }}-
-            ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-editor-
-            ${{ github.event.client_payload.repoVersionFull }}-${{ runner.os }}-buildx-
       ###########################
       #    Free disk space   #
       ###########################


### PR DESCRIPTION
#### Changes

- Remove the cache step in editor image workflows.
- The cache size for GitHub Actions is 5GB, but this is insufficient for caching editor images.
https://github.com/game-ci/docker/runs/2010373210?check_suite_focus=true#step:35:3
> A repository can have up to 5GB of caches. Once the 5GB limit is reached, older caches will be evicted based on when the cache was last accessed. Caches that are not accessed within the last week will also be evicted.
- The cache API increases the build time.
`Cache Docker layers` step takes 2m45s, `Post Cache Docker layers` step takes 2m35s.
https://github.com/game-ci/docker/runs/2010373210?check_suite_focus=true

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
