### PR TITLE
2019-lib-fixes

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -183,9 +183,9 @@ RUN [ `echo $module | grep -v '\(webgl\|linux-il2cpp\)'` ] && exit 0 || : \
   && rm -rf /var/lib/apt/lists/*
 
 #=======================================================================================
-# [2019.1.x] libnotify4 libunwind-dev libssl1.0
+# [2019.x] libnotify4 libunwind-dev libssl1.0
 #=======================================================================================
-RUN [ `echo $version | grep -v '^2019.1.'` ] && exit 0 || : \
+RUN [ `echo $version | grep -v '^2019.'` ] && exit 0 || : \
   && apt-get -q update \
   && apt-get -q install -y --no-install-recommends --allow-downgrades \
     libnotify4 \


### PR DESCRIPTION
#### Changes

Extend range for library installs to full 2019 range as per https://github.com/game-ci/docker/issues/57#issuecomment-799635864 from @HmSebastianH 

- add `libnotify4`
- add `libunwind-dev`
- add `libssl1.0`
- Added size for 2019.2.x up to 2019.4.x editor images: 10 megs
- 2019.1 unchanged since https://github.com/game-ci/docker/pull/59

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
