### PR TITLE
Adds `runner` user in hub/Dockerfile

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,13 @@
 FROM ubuntu:18.04
 
+# Runner user parameters
+ARG UNAME=runner
+ENV UNAME=$UNAME
+ARG UID=1000
+ENV UID=$UID
+ARG GID=1000
+ENV GID=$GID
+
 # Global dependencies
 RUN apt-get -q update \
  && apt-get -q install -y --no-install-recommends apt-utils \
@@ -24,6 +32,7 @@ RUN apt-get -q update \
 # Toolbox
 RUN apt-get -q update \
  && apt-get -q install -y --no-install-recommends --allow-downgrades \
+ sudo \
  atop \
  curl \
  git \
@@ -44,3 +53,17 @@ ENV UNITY_PATH="/opt/unity"
 # Fixes a Gradle crash while building for Android on Unity 2019 when there are accented characters in environment variables
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
+
+# Create the runner user
+RUN groupadd -g $GID $UNAME
+RUN useradd -u $UID -g $UNAME -s /bin/sh -m $UNAME
+
+# Give relevant executable folders to runner user
+RUN mkdir -p $UNITY_PATH && chown $UID:$GID $UNITY_PATH
+RUN chown $UID:$GID /usr/bin
+
+# Let the runner user use apt-get and rm without a password
+RUN echo ${UNAME}" ALL = NOPASSWD : /bin/rm , /usr/bin/apt-get" > /etc/sudoers.d/apt
+
+# Run as runner user for the rest of the steps
+USER $UID:$GID

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -29,7 +29,7 @@ FROM $baseImage
 # Always put "Editor" and "modules.json" directly in $UNITY_PATH
 ARG version
 ARG module
-COPY --from=builder /opt/unity/editors/$version/ "$UNITY_PATH/"
+COPY --from=builder $UNITY_PATH/editors/$version/ "$UNITY_PATH/"
 
 # Add a file containing the version for this build
 RUN echo $version > "$UNITY_PATH/version"
@@ -85,8 +85,8 @@ RUN [ `echo $version-$module | grep -v '^\(2018.3\|2018.4\).*-android'` ] && exi
   && export PATH=$JAVA_HOME/bin:${ANDROID_SDK_ROOT}/tools:${ANDROID_SDK_ROOT}/tools/bin:${ANDROID_SDK_ROOT}/platform-tools:${PATH} \
   \
   # Download Android SDK (commandline tools) 26.1.1
-  && apt-get update -qq \
-  && apt-get install -qq -y --no-install-recommends unzip \
+  && sudo apt-get update -qq \
+  && sudo apt-get install -qq -y --no-install-recommends unzip \
   && mkdir -p ${ANDROID_SDK_ROOT} \
   && chown -R 777 ${ANDROID_INSTALL_LOCATION} \
   && wget -q https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -O /tmp/android-sdk.zip \
@@ -103,8 +103,8 @@ RUN [ `echo $version-$module | grep -v '^\(2018.3\|2018.4\).*-android'` ] && exi
   && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \
   \
   # Clean up
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* \
+  && sudo apt-get clean \
+  && sudo rm -rf /var/lib/apt/lists/* \
   && rm -rf /tmp/* \
   \
   # Update alias 'unity-editor'
@@ -135,8 +135,8 @@ RUN [ `echo $version-$module | grep -v '^\(2018.3\|2018.4\).*-android'` ] && exi
 RUN [ `echo $version-$module | grep -vP '^20(?!18).*-android'` ] && exit 0 || : \
   \
   # Install jq
-  && apt-get update -qq \
-  && apt-get install -qq -y --no-install-recommends jq \
+  && sudo apt-get update -qq \
+  && sudo apt-get install -qq -y --no-install-recommends jq \
   \
   # Environment Variables
   && export RAW_ANDROID_SDK_ROOT=$(jq -cr '(.[] | select(.id == "android-sdk-platform-tools")).destination' $UNITY_PATH/modules.json) \
@@ -153,9 +153,9 @@ RUN [ `echo $version-$module | grep -vP '^20(?!18).*-android'` ] && exit 0 || : 
   && export PATH=$JAVA_HOME/bin:${ANDROID_SDK_ROOT}/tools:${ANDROID_SDK_ROOT}/tools/bin:${ANDROID_SDK_ROOT}/platform-tools:${PATH} \
   \
   # Clean up
-  && apt-get remove -y jq \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* \
+  && sudo apt-get remove -y jq \
+  && sudo apt-get clean \
+  && sudo rm -rf /var/lib/apt/lists/* \
   \
   # Accept licenses
   && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \
@@ -186,36 +186,36 @@ RUN [ `echo $version-$module | grep -vP '^20(?!18).*-android'` ] && exit 0 || : 
 # [webgl] Support audio using ffmpeg (~99MB)
 #=======================================================================================
 RUN [ `echo $module | grep -v 'webgl'` ] && exit 0 || : \
-  && apt-get update \
-  && apt-get -q install -y --no-install-recommends --allow-downgrades \
+  && sudo apt-get update \
+  && sudo apt-get -q install -y --no-install-recommends --allow-downgrades \
     ffmpeg \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && sudo apt-get clean \
+  && sudo rm -rf /var/lib/apt/lists/*
 
 #=======================================================================================
 # [webgl, il2cpp] python python-setuptools build-essential clang
 #=======================================================================================
 RUN [ `echo $module | grep -v '\(webgl\|linux-il2cpp\)'` ] && exit 0 || : \
-  && apt-get -q update \
-  && apt-get -q install -y --no-install-recommends --allow-downgrades \
+  && sudo apt-get -q update \
+  && sudo apt-get -q install -y --no-install-recommends --allow-downgrades \
     python \
     python-setuptools \
     build-essential \
     clang \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && sudo apt-get clean \
+  && sudo rm -rf /var/lib/apt/lists/*
 
 #=======================================================================================
 # [2019.x] libnotify4 libunwind-dev libssl1.0
 #=======================================================================================
 RUN [ `echo $version | grep -v '^2019.'` ] && exit 0 || : \
-  && apt-get -q update \
-  && apt-get -q install -y --no-install-recommends --allow-downgrades \
+  && sudo apt-get -q update \
+  && sudo apt-get -q install -y --no-install-recommends --allow-downgrades \
     libnotify4 \
     libunwind-dev \
     libssl1.0  \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && sudo apt-get clean \
+  && sudo rm -rf /var/lib/apt/lists/*
 
 #=======================================================================================
 # [2018.x/2019.x/2020.1.x-webgl] support brotli compression for linux
@@ -229,8 +229,8 @@ RUN [ `echo $version-$module | grep -v '^\(2018\|2019\|2020.1\).*-webgl'` ] && e
 # [2021.x-linux-il2cpp] lld
 #=======================================================================================
 RUN [ `echo $version-$module | grep -v '^2021.*-linux-il2cpp'` ] && exit 0 || : \
-  && apt-get -q update \
-  && apt-get -q install -y --no-install-recommends --allow-downgrades \
+  && sudo apt-get -q update \
+  && sudo apt-get -q install -y --no-install-recommends --allow-downgrades \
     lld \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && sudo apt-get clean \
+  && sudo rm -rf /var/lib/apt/lists/*

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -2,29 +2,25 @@ ARG baseImage="unityci/base"
 FROM $baseImage
 
 # Hub dependencies
-RUN apt-get -q update \
- && apt-get -q install -y --no-install-recommends --allow-downgrades zenity \
- && apt-get clean
+RUN sudo apt-get -q update \
+ && sudo apt-get -q install -y --no-install-recommends --allow-downgrades zenity \
+ && sudo apt-get clean
 
 # Download & extract AppImage
 RUN wget --no-verbose -O /tmp/UnityHub.AppImage "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage" \
  && chmod +x /tmp/UnityHub.AppImage \
  && cd /tmp \
  && /tmp/UnityHub.AppImage --appimage-extract \
- && cp -R /tmp/squashfs-root/* / \
- && rm -rf /tmp/squashfs-root /tmp/UnityHub.AppImage \
  && mkdir -p "$UNITY_PATH" \
- && mv /AppRun /opt/unity/UnityHub
+ && cp -R /tmp/squashfs-root/* $UNITY_PATH \
+ && rm -rf /tmp/squashfs-root /tmp/UnityHub.AppImage \
+ && mv $UNITY_PATH/AppRun $UNITY_PATH/UnityHub
 
 # Alias to "unity-hub" with default params
-RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout /opt/unity/UnityHub --no-sandbox --headless "$@"' > /usr/bin/unity-hub \
+RUN echo '#!/bin/bash\nAPPIMAGE_SILENT_INSTALL=true APPDIR='$UNITY_PATH' xvfb-run -ae /dev/stdout '$UNITY_PATH'/UnityHub --no-sandbox --headless "$@"' > /usr/bin/unity-hub \
  && chmod +x /usr/bin/unity-hub
-
-# Accept
-RUN mkdir -p "/root/.config/Unity Hub" \
- && touch "/root/.config/Unity Hub/eulaAccepted"
 
 # Configure
 RUN mkdir -p "${UNITY_PATH}/editors" \
  && unity-hub install-path --set "${UNITY_PATH}/editors/" \
- && find /tmp -mindepth 1 -delete
+ && find /tmp -mindepth 1 -delete 2> /dev/null

--- a/hub/Dockerfile
+++ b/hub/Dockerfile
@@ -17,7 +17,7 @@ RUN wget --no-verbose -O /tmp/UnityHub.AppImage "https://public-cdn.cloud.unity3
  && mv $UNITY_PATH/AppRun $UNITY_PATH/UnityHub
 
 # Alias to "unity-hub" with default params
-RUN echo '#!/bin/bash\nAPPIMAGE_SILENT_INSTALL=true APPDIR='$UNITY_PATH' xvfb-run -ae /dev/stdout '$UNITY_PATH'/UnityHub --no-sandbox --headless "$@"' > /usr/bin/unity-hub \
+RUN echo '#!/bin/bash\nAPPIMAGE_SILENT_INSTALL=true APPDIR=$UNITY_PATH xvfb-run -ae /dev/stdout $UNITY_PATH/UnityHub --no-sandbox --headless "$@"' > /usr/bin/unity-hub \
  && chmod +x /usr/bin/unity-hub
 
 # Configure


### PR DESCRIPTION
#### Changes

- Adds a `runner` user with uid:gid `1000:1000` in `hub/Dockerfile`
- This is intended to allow downstream steps to run as this user and not create root-owned files

*c.f:* [game-ci/unity-builder issue #219](https://github.com/game-ci/unity-builder/issues/219)


#### Explanation

(From comment: https://github.com/game-ci/docker/pull/106#issuecomment-830375895)

Here's what we're doing:

In `base/Dockerfile`:
- [Add `UNAME`, `UID` and `GID`](https://github.com/Bradshaw/docker/blob/f5f67e561ebb2500b6a6663ef8cb9645795d482f/base/Dockerfile#L3-L9) that we use to parameterise our non-root user. By default: `runner 1000:1000`.
- [Install `sudo`](https://github.com/Bradshaw/docker/blob/f5f67e561ebb2500b6a6663ef8cb9645795d482f/base/Dockerfile#L35)
- [Create the runner user](https://github.com/Bradshaw/docker/blob/f5f67e561ebb2500b6a6663ef8cb9645795d482f/base/Dockerfile#L57-L59)
- [`chown` key executable folders to `runner`](https://github.com/Bradshaw/docker/blob/f5f67e561ebb2500b6a6663ef8cb9645795d482f/base/Dockerfile#L61-L63) (this lets us write to executable folders)
- [Let `runner` use `sudo apt-get` and `sudo rm` without a password](https://github.com/Bradshaw/docker/blob/f5f67e561ebb2500b6a6663ef8cb9645795d482f/base/Dockerfile#L65-L66)
- [And then switch to user `runner`](https://github.com/Bradshaw/docker/blob/f5f67e561ebb2500b6a6663ef8cb9645795d482f/base/Dockerfile#L68-L69)

In `hub/Dockerfile` (now running as `runner 1000:1000`)
- [Use `sudo apt-get`](https://github.com/Bradshaw/docker/blob/f5f67e561ebb2500b6a6663ef8cb9645795d482f/hub/Dockerfile#L5-L7) (we won't be bothered for a password)
- [Install Unity files to `$UNITY_PATH`](https://github.com/Bradshaw/docker/blob/f5f67e561ebb2500b6a6663ef8cb9645795d482f/hub/Dockerfile#L9-L17) (instead of `/`)
- [Use `APPIMAGE_SILENT_INSTALL` and `APPDIR` env vars in `/usr/bin/unity-hub`](https://github.com/Bradshaw/docker/blob/f5f67e561ebb2500b6a6663ef8cb9645795d482f/hub/Dockerfile#L19-L21) (Silent install skips EULA check, appdir lets the UnityHub script know where to look for Unity files)

In `editor/Dockerfile`:
- Use `sudo apt-get` and `sudo rm` a whole bunch 🤷

All of these are now running as `runner` (or whatever you pass as `UNAME` build parameter.

We don't *need* to have `UNAME`, `UID` and `GID` copied to env vars, but it might be useful if dependants want to `USER 0:0` to run some stuff and be able to `USER $UID:$GID` back...


#### Caveats and other information

- This breaks pipelines that depend on root user (including [game-ci/unity-builder](https://github.com/game-ci/unity-builder). If they want to use these images, they need to add a `USER root` command, or not rely on root any more
- If the runner user id and group id don't exist on the host system, it can cause some issues too, since the files will belong to an invalid user and group.
- It is possible to run images as a custom user (*e.g:* `docker run -u 1337:4242`), but there can be issues if the user doesn't exist in the image. It's possible to solve this by creating an image that imports these images and creating a user there before continuing.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme not needed
- [ ] Update tests to check that the generated files belong to `runner` after building the test project
