### PR TITLE
Install Unity Hub from Unity Hub Debian repository

### DIFF
--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -165,6 +165,7 @@ RUN echo "$version-$module" | grep -q -vP '^20(?!18).*android' \
   \
   # Let other users to run sdkmanager as well
   && chmod 755 "${ANDROID_HOME}/tools/bin/sdkmanager" \
+  && chmod 755 "${JAVA_HOME}/bin/java" \
   \
   # Accept licenses
   && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \  

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -166,6 +166,7 @@ RUN echo "$version-$module" | grep -q -vP '^20(?!18).*android' \
   # Let other users to run sdkmanager as well
   && chmod 755 "${ANDROID_HOME}/tools/bin/sdkmanager" \
   && chmod 755 "${JAVA_HOME}/bin/java" \
+  && chmod 755 "${ANDROID_HOME}/tools/android" \
   \
   # Accept licenses
   && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \  

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -163,11 +163,11 @@ RUN echo "$version-$module" | grep -q -vP '^20(?!18).*android' \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   \
-  # Accept licenses
-  && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \
-  \
   # Let other users to run sdkmanager as well
   && chmod 755 "${ANDROID_HOME}/tools/bin/sdkmanager" \
+  \
+  # Accept licenses
+  && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \  
   \
   # Update alias 'unity-editor'
   && { \

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -163,10 +163,10 @@ RUN echo "$version-$module" | grep -q -vP '^20(?!18).*android' \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   \
-  # Let other users to run sdkmanager as well
-  && chmod 755 "${ANDROID_HOME}/tools/bin/sdkmanager" \
-  && chmod 755 "${JAVA_HOME}/bin/java" \
-  && chmod 755 "${ANDROID_HOME}/tools/android" \
+  # Set execute permissions for Android SDK, NDK, Java
+  && chmod -R 755 "${ANDROID_HOME}" \
+  && chmod -R 755 "${JAVA_HOME}" \
+  && chmod -R 755 "${ANDROID_NDK_HOME}" \
   \
   # Accept licenses
   && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \  

--- a/images/ubuntu/hub/Dockerfile
+++ b/images/ubuntu/hub/Dockerfile
@@ -1,5 +1,6 @@
 ARG baseImage="unityci/base"
 FROM $baseImage
+ARG hubVersion="3.0.0"
 
 # Hub dependencies
 RUN apt-get -q update \
@@ -11,7 +12,7 @@ RUN apt-get -q update \
 RUN sh -c 'echo "deb https://hub.unity3d.com/linux/repos/deb stable main" > /etc/apt/sources.list.d/unityhub.list' \
  && wget -qO - https://hub.unity3d.com/linux/keys/public | apt-key add - \
  && apt-get -q update \
- && apt-get -q install -y unityhub \
+ && apt-get -q install -y unityhub=$hubVersion \
  && apt-get clean
 
 # Alias to "unity-hub" with default params

--- a/images/ubuntu/hub/Dockerfile
+++ b/images/ubuntu/hub/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get -q update \
 RUN sh -c 'echo "deb https://hub.unity3d.com/linux/repos/deb stable main" > /etc/apt/sources.list.d/unityhub.list' \
  && wget -qO - https://hub.unity3d.com/linux/keys/public | apt-key add - \
  && apt-get -q update \
- && apt-get -q install -y unityhub=$hubVersion \
+ && apt-get -q install -y "unityhub=$hubVersion" \
  && apt-get clean
 
 # Alias to "unity-hub" with default params

--- a/images/ubuntu/hub/Dockerfile
+++ b/images/ubuntu/hub/Dockerfile
@@ -3,26 +3,20 @@ FROM $baseImage
 
 # Hub dependencies
 RUN apt-get -q update \
- && apt-get -q install -y --no-install-recommends --allow-downgrades zenity \
+ && apt-get -q install -y --no-install-recommends --allow-downgrades zenity libgbm1 gnupg \
  && apt-get clean
 
-# Download & extract AppImage
-RUN wget --no-verbose -O /tmp/UnityHub.AppImage "https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage" \
- && chmod +x /tmp/UnityHub.AppImage \
- && cd /tmp \
- && /tmp/UnityHub.AppImage --appimage-extract \
- && cp -R /tmp/squashfs-root/* / \
- && rm -rf /tmp/squashfs-root /tmp/UnityHub.AppImage \
- && mkdir -p "$UNITY_PATH" \
- && mv /AppRun /opt/unity/UnityHub
+# Install Unity Hub
+# https://docs.unity3d.com/hub/manual/InstallHub.html#install-hub-linux
+RUN sh -c 'echo "deb https://hub.unity3d.com/linux/repos/deb stable main" > /etc/apt/sources.list.d/unityhub.list' \
+ && wget -qO - https://hub.unity3d.com/linux/keys/public | apt-key add - \
+ && apt-get -q update \
+ && apt-get -q install -y unityhub \
+ && apt-get clean
 
 # Alias to "unity-hub" with default params
-RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout /opt/unity/UnityHub --no-sandbox --headless "$@"' > /usr/bin/unity-hub \
+RUN echo '#!/bin/bash\nxvfb-run -ae /dev/stdout /opt/unityhub/unityhub-bin --no-sandbox --headless "$@"' > /usr/bin/unity-hub \
  && chmod +x /usr/bin/unity-hub
-
-# Accept
-RUN mkdir -p "/root/.config/Unity Hub" \
- && touch "/root/.config/Unity Hub/eulaAccepted"
 
 # Configure
 RUN mkdir -p "${UNITY_PATH}/editors" \


### PR DESCRIPTION


#### Changes

- Install Unity Hub from Unity Hub Debian repository. This installs Unity Hub 3.0. Current implementation installs Unity Hub 2.x.
 https://docs.unity3d.com/hub/manual/InstallHub.html#install-hub-linux

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (not needed)
