### PR TITLE
Fix Android image size

### DIFF
--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -20,7 +20,9 @@ RUN for mod in $module; do \
       else \
         unity-hub install-modules --version "$version" --module "$mod" --childModules | tee /var/log/install-module-${mod}.log && grep 'Missing module' /var/log/install-module-${mod}.log | exit $(wc -l); \
       fi \
-    done
+    done \
+	# Set execute permissions for modules
+	&& chmod -R 755 /opt/unity/editors/$version/Editor/Data/PlaybackEngines
 
 ###########################
 #          Editor         #
@@ -162,12 +164,6 @@ RUN echo "$version-$module" | grep -q -vP '^20(?!18).*android' \
   && apt-get remove -y jq \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
-  \
-  # Set execute permissions for Android SDK, NDK, Java
-  && chmod -R 755 "${ANDROID_HOME}" \
-  && chmod -R 755 "${JAVA_HOME}" \
-  && chmod -R 755 "${ANDROID_NDK_HOME}" \
-  \
   # Accept licenses
   && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \  
   \


### PR DESCRIPTION
Set permissions inside of the builder before copying to reduce resulting image size.

Android image size got increased after implementing Hub 3.0:
[ubuntu-2021.2.6f1-android-0.15.0](https://hub.docker.com/layers/unityci/editor/ubuntu-2021.2.6f1-android-0.15.0/images/sha256-0e4061d36042f35fd224a13a79960ab2b2164ef30d9a2f2e68b0abfc3ec7cb03?context=explore)
[ubuntu-2021.2.6f1-android-0.16.0](https://hub.docker.com/layers/unityci/editor/ubuntu-2021.2.6f1-android-0.16.0/images/sha256-19318e13ce3e21327cb36fc1d51c080a1e7809bc27b14d4c1bec19fb14a75cbc?context=explore)