### PR TITLE
chore: phase out old workflow tags

### DIFF
--- a/.github/workflows/new-ubuntu-base-image-requested.yml
+++ b/.github/workflows/new-ubuntu-base-image-requested.yml
@@ -2,7 +2,9 @@ name: New Ubuntu Base Version ⛭
 
 on:
   repository_dispatch:
-    types: [new_base_image_requested, new_ubuntu_base_image_requested]
+    types:
+      - new_base_images_requested
+      - new_ubuntu_base_image_requested
 
 # Further reading:
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch

--- a/.github/workflows/new-ubuntu-hub-image-requested.yml
+++ b/.github/workflows/new-ubuntu-hub-image-requested.yml
@@ -2,7 +2,9 @@ name: New Ubuntu Hub Version ⚙
 
 on:
   repository_dispatch:
-    types: [ new_hub_image_requested, new_ubuntu_hub_image_requested ]
+    types:
+      - new_hub_images_requested
+      - new_ubuntu_hub_image_requested
 
 # Further reading:
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch

--- a/.github/workflows/new-ubuntu-legacy-editor-image-requested.yml
+++ b/.github/workflows/new-ubuntu-legacy-editor-image-requested.yml
@@ -2,7 +2,8 @@ name: New Ubuntu Editor Version 🗔
 
 on:
   repository_dispatch:
-    types: [ new_legacy_editor_image_requested, new_ubuntu_legacy_editor_image_requested ]
+    types:
+      - new_ubuntu_legacy_editor_image_requested
 
 # Further reading:
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch

--- a/.github/workflows/new-ubuntu-post-2019-2-editor-image-requested.yml
+++ b/.github/workflows/new-ubuntu-post-2019-2-editor-image-requested.yml
@@ -2,7 +2,8 @@ name: New Ubuntu Editor Version 🗔
 
 on:
   repository_dispatch:
-    types: [ new_2019_3_plus_editor_image_requested, new_ubuntu_post_2019_2_editor_image_requested ]
+    types:
+      - new_ubuntu_post_2019_2_editor_image_requested
 
 # Further reading:
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch

--- a/.github/workflows/new-windows-base-image-requested.yml
+++ b/.github/workflows/new-windows-base-image-requested.yml
@@ -2,7 +2,9 @@ name: New Windows Base Version ⛭
 
 on:
   repository_dispatch:
-    types: [new_windows_base_image_requested]
+    types:
+      - new_base_images_requested
+      - new_windows_base_image_requested
   workflow_dispatch:
     inputs:
       jobId:

--- a/.github/workflows/new-windows-base-image-requested.yml
+++ b/.github/workflows/new-windows-base-image-requested.yml
@@ -12,17 +12,14 @@ on:
         required: true
         default: 'dryRun'
       repoVersionFull:
-        description: 'Docker Repo Version Full'
+        description: 'All digits of the latest tag of this repository, e.g. `1.23.45`'
         required: true
-        default: '0.15'
       repoVersionMinor:
-        description: 'Docker Repo Version Minor'
+        description: 'Minor digit of that tag, e.g. `23`'
         required: true
-        default: '15'
       repoVersionMajor:
-        description: 'Docker Repo Version Major'
+        description: 'Major digit of that tag, e.g. `1`'
         required: true
-        default: '0'
 
 # Further reading:
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch

--- a/.github/workflows/new-windows-hub-image-requested.yml
+++ b/.github/workflows/new-windows-hub-image-requested.yml
@@ -2,7 +2,9 @@ name: New Windows Hub Version ⚙
 
 on:
   repository_dispatch:
-    types: [ new_windows_hub_image_requested ]
+    types:
+      - new_hub_images_requested
+      - new_windows_hub_image_requested
   workflow_dispatch:
     inputs:
       jobId:

--- a/.github/workflows/new-windows-hub-image-requested.yml
+++ b/.github/workflows/new-windows-hub-image-requested.yml
@@ -12,17 +12,14 @@ on:
         required: true
         default: 'dryRun'
       repoVersionFull:
-        description: 'Docker Repo Version Full'
+        description: 'All digits of the latest tag of this repository, e.g. `1.23.45`'
         required: true
-        default: '0.15'
       repoVersionMinor:
-        description: 'Docker Repo Version Minor'
+        description: 'Minor digit of that tag, e.g. `23`'
         required: true
-        default: '15'
       repoVersionMajor:
-        description: 'Docker Repo Version Major'
+        description: 'Major digit of that tag, e.g. `1`'
         required: true
-        default: '0'
 
 # Further reading:
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch

--- a/.github/workflows/new-windows-legacy-editor-image-requested.yml
+++ b/.github/workflows/new-windows-legacy-editor-image-requested.yml
@@ -19,17 +19,14 @@ on:
         required: true
         default: '79c78de19888'
       repoVersionFull:
-        description: 'Docker Repo Version Full'
+        description: 'All digits of the latest tag of this repository, e.g. `1.23.45`'
         required: true
-        default: '0.15'
       repoVersionMinor:
-        description: 'Docker Repo Version Minor'
+        description: 'Minor digit of that tag, e.g. `23`'
         required: true
-        default: '15'
       repoVersionMajor:
-        description: 'Docker Repo Version Major'
+        description: 'Major digit of that tag, e.g. `1`'
         required: true
-        default: '0'
 
 # Further reading:
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch

--- a/.github/workflows/new-windows-legacy-editor-image-requested.yml
+++ b/.github/workflows/new-windows-legacy-editor-image-requested.yml
@@ -2,7 +2,8 @@ name: New Windows Editor Version 🗔
 
 on:
   repository_dispatch:
-    types: [ new_windows_legacy_editor_image_requested ]
+    types:
+      - new_windows_legacy_editor_image_requested
   workflow_dispatch:
     inputs:
       jobId:

--- a/.github/workflows/new-windows-post-2019-2-editor-image-requested.yml
+++ b/.github/workflows/new-windows-post-2019-2-editor-image-requested.yml
@@ -19,17 +19,14 @@ on:
         required: true
         default: '79c78de19888'
       repoVersionFull:
-        description: 'Docker Repo Version Full'
+        description: 'All digits of the latest tag of this repository, e.g. `1.23.45`'
         required: true
-        default: '0.15'
       repoVersionMinor:
-        description: 'Docker Repo Version Minor'
+        description: 'Minor digit of that tag, e.g. `23`'
         required: true
-        default: '15'
       repoVersionMajor:
-        description: 'Docker Repo Version Major'
+        description: 'Major digit of that tag, e.g. `1`'
         required: true
-        default: '0'
 
 # Further reading:
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch

--- a/.github/workflows/new-windows-post-2019-2-editor-image-requested.yml
+++ b/.github/workflows/new-windows-post-2019-2-editor-image-requested.yml
@@ -2,7 +2,8 @@ name: New Windows Editor Version 🗔
 
 on:
   repository_dispatch:
-    types: [ new_windows_post_2019_2_editor_image_requested ]
+    types:
+      - new_windows_post_2019_2_editor_image_requested
   workflow_dispatch:
     inputs:
       jobId:

--- a/.github/workflows/retry-ubuntu-editor-image-requested.yml
+++ b/.github/workflows/retry-ubuntu-editor-image-requested.yml
@@ -2,7 +2,8 @@ name: Retry Building Ubuntu Editor Version 🗔
 
 on:
   repository_dispatch:
-    types: [ retry_editor_image_requested, retry_ubuntu_editor_image_requested ]
+    types:
+      - retry_ubuntu_editor_image_requested
 
 # Further reading:
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch

--- a/.github/workflows/retry-windows-editor-image-requested.yml
+++ b/.github/workflows/retry-windows-editor-image-requested.yml
@@ -2,7 +2,8 @@ name: Retry Building Windows Editor Version 🗔
 
 on:
   repository_dispatch:
-    types: [ retry_windows_editor_image_requested ]
+    types:
+      - retry_windows_editor_image_requested
 
 # Further reading:
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch
@@ -16,7 +17,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      
+
       #################
       #   Variables   #
       #################
@@ -30,7 +31,7 @@ jobs:
           echo "repoVersion (full): ${{ github.event.client_payload.repoVersionFull }}"
           echo "repoVersion (only minor and major): ${{ github.event.client_payload.repoVersionMinor }}"
           echo "repoVersion (only major): ${{ github.event.client_payload.repoVersionMajor }}"
-      
+
       - name: Report new build
         uses: ./.github/workflows/actions/report-to-backend
         with:
@@ -43,7 +44,7 @@ jobs:
           repoVersion: ${{ github.event.client_payload.repoVersionFull }}
           editorVersion: ${{ github.event.client_payload.editorVersion }}
           targetPlatform: ${{ github.event.client_payload.targetPlatform }}
-      
+
       #############
       #   Setup   #
       #############
@@ -52,7 +53,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
         run: docker login --username $Env:username --password $Env:password
-      
+
       - name: Check if image not already exists
         run: |
           # Source: https://stackoverflow.com/a/39731444/3593896
@@ -71,7 +72,7 @@ jobs:
             echo "Image already exists. Exiting."
             exit 1
           }
-      
+
       #######################
       #   Free disk space   #
       #######################
@@ -104,7 +105,7 @@ jobs:
                 --push
           ### Warning: If we once publish latest, we will have to do it forever. Lets not do that unless it's needed ###
           ### Another warning: order is important: We go from specific to unspecific with the exception of the most specific tag which is used to check if the image is already there ###
-      
+
       #######################
       #   Retry the above   #
       #######################
@@ -130,7 +131,7 @@ jobs:
       - name: Inspect
         run: |
           docker buildx imagetools inspect unityci/editor:windows-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}
-      
+
       - name: Image digest
         id: image-digest
         if: ${{ success() }}
@@ -160,7 +161,7 @@ jobs:
           friendlyTag: windows-${{ github.event.client_payload.repoVersionMinor }}
           specificTag: windows-${{ github.event.client_payload.repoVersionFull }}
           digest: ${{ steps.image-digest.outputs.digest }}
-      
+
       - name: Report failure
         if: ${{ failure() || cancelled() }}
         uses: ./.github/workflows/actions/report-to-backend
@@ -176,7 +177,7 @@ jobs:
           targetPlatform: ${{ github.event.client_payload.targetPlatform }}
           # Failure info
           reason: ${{ job.status }}
-      
+
       ###############
       #   Metrics   #
       ###############


### PR DESCRIPTION
#### Changes

- For base and hub images we build for all base platforms at the same time, tags are shared
- For legacy and specific version editor workflows we keep them separated, so that we can manage workflows for different baseOses separately.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
