### PR TITLE
chore: one more change to the build triggers

### DIFF
--- a/.github/workflows/new-ubuntu-legacy-editor-image-requested.yml
+++ b/.github/workflows/new-ubuntu-legacy-editor-image-requested.yml
@@ -3,7 +3,8 @@ name: New Ubuntu Editor Version 🗔
 on:
   repository_dispatch:
     types:
-      - new_ubuntu_legacy_editor_image_requested
+      - new_legacy_editor_image_requested
+      - new_ubuntu_legacy_editor_image_requested # deprecated
 
 # Further reading:
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch

--- a/.github/workflows/new-ubuntu-post-2019-2-editor-image-requested.yml
+++ b/.github/workflows/new-ubuntu-post-2019-2-editor-image-requested.yml
@@ -3,7 +3,8 @@ name: New Ubuntu Editor Version 🗔
 on:
   repository_dispatch:
     types:
-      - new_ubuntu_post_2019_2_editor_image_requested
+      - new_post_2019_2_editor_image_requested
+      - new_ubuntu_post_2019_2_editor_image_requested # deprecated
 
 # Further reading:
 # https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch

--- a/.github/workflows/new-windows-legacy-editor-image-requested.yml
+++ b/.github/workflows/new-windows-legacy-editor-image-requested.yml
@@ -3,7 +3,8 @@ name: New Windows Editor Version 🗔
 on:
   repository_dispatch:
     types:
-      - new_windows_legacy_editor_image_requested
+      - new_legacy_editor_image_requested
+      - new_windows_legacy_editor_image_requested # deprecated
   workflow_dispatch:
     inputs:
       jobId:

--- a/.github/workflows/new-windows-post-2019-2-editor-image-requested.yml
+++ b/.github/workflows/new-windows-post-2019-2-editor-image-requested.yml
@@ -3,7 +3,8 @@ name: New Windows Editor Version 🗔
 on:
   repository_dispatch:
     types:
-      - new_windows_post_2019_2_editor_image_requested
+      - new_post_2019_2_editor_image_requested
+      - new_windows_post_2019_2_editor_image_requested # deprecated
   workflow_dispatch:
     inputs:
       jobId:
@@ -57,25 +58,25 @@ jobs:
       - name: Setup Build Parameters
         id: buildParameters
         run: |
-              if (${{ github.event.inputs.jobId }})
-              {
-                # Workflow Dispatch
-                echo '::set-output jobId=${{ github.event.inputs.jobId }}'
-                echo '::set-output editorVersion=${{ github.event.inputs.editorVersion }}'
-                echo '::set-output changeSet=${{ github.event.inputs.changeSet }}'
-                echo '::set-output repoVersionFull=${{ github.event.inputs.repoVersionFull }}'
-                echo '::set-output repoVersionMinor=${{ github.event.inputs.repoVersionMinor }}'
-                echo '::set-output repoVersionMajor=${{ github.event.inputs.repoVersionMajor }}'
-              } else
-              {
-                # Repo Dispatch
-                echo '::set-output jobId=${{ github.event.client_payload.jobId }}'
-                echo '::set-output editorVersion=${{ github.event.client_payload.editorVersion }}'
-                echo '::set-output changeSet=${{ github.event.client_payload.changeSet }}'
-                echo '::set-output repoVersionFull=${{ github.event.client_payload.repoVersionFull }}'
-                echo '::set-output repoVersionMinor=${{ github.event.client_payload.repoVersionMinor }}'
-                echo '::set-output repoVersionMajor=${{ github.event.client_payload.repoVersionMajor }}'
-              }
+          if (${{ github.event.inputs.jobId }})
+          {
+            # Workflow Dispatch
+            echo '::set-output jobId=${{ github.event.inputs.jobId }}'
+            echo '::set-output editorVersion=${{ github.event.inputs.editorVersion }}'
+            echo '::set-output changeSet=${{ github.event.inputs.changeSet }}'
+            echo '::set-output repoVersionFull=${{ github.event.inputs.repoVersionFull }}'
+            echo '::set-output repoVersionMinor=${{ github.event.inputs.repoVersionMinor }}'
+            echo '::set-output repoVersionMajor=${{ github.event.inputs.repoVersionMajor }}'
+          } else
+          {
+            # Repo Dispatch
+            echo '::set-output jobId=${{ github.event.client_payload.jobId }}'
+            echo '::set-output editorVersion=${{ github.event.client_payload.editorVersion }}'
+            echo '::set-output changeSet=${{ github.event.client_payload.changeSet }}'
+            echo '::set-output repoVersionFull=${{ github.event.client_payload.repoVersionFull }}'
+            echo '::set-output repoVersionMinor=${{ github.event.client_payload.repoVersionMinor }}'
+            echo '::set-output repoVersionMajor=${{ github.event.client_payload.repoVersionMajor }}'
+          }
 
       - name: Show hook input
         run: |
@@ -149,15 +150,15 @@ jobs:
         id: build_windows_editor_image
         continue-on-error: true
         run: |
-              docker build ./images/windows/editor/ `
-                --build-arg hubImage=unityci/hub:windows-${{ steps.buildParameters.outputs.repoVersionFull }} `
-                --build-arg baseImage=unityci/base:windows-${{ steps.buildParameters.outputs.repoVersionFull }} `
-                --build-arg version=${{ steps.buildParameters.outputs.editorVersion }} `
-                --build-arg changeSet=${{ steps.buildParameters.outputs.changeSet }} `
-                --tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionMinor }} `
-                --tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionMajor }} `
-                --tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionFull }} `
-                --push
+          docker build ./images/windows/editor/ `
+            --build-arg hubImage=unityci/hub:windows-${{ steps.buildParameters.outputs.repoVersionFull }} `
+            --build-arg baseImage=unityci/base:windows-${{ steps.buildParameters.outputs.repoVersionFull }} `
+            --build-arg version=${{ steps.buildParameters.outputs.editorVersion }} `
+            --build-arg changeSet=${{ steps.buildParameters.outputs.changeSet }} `
+            --tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionMinor }} `
+            --tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionMajor }} `
+            --tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionFull }} `
+            --push
           ### Warning: If we once publish latest, we will have to do it forever. Lets not do that unless it's needed ###
           ### Another warning: order is important: We go from specific to unspecific with the exception of the most specific tag which is used to check if the image is already there ###
 
@@ -168,15 +169,15 @@ jobs:
         if: steps.build_windows_editor_image.outcome=='failure'
         id: build_windows_editor_image_retry
         run: |
-              docker build ./images/windows/editor/ `
-                --build-arg hubImage=unityci/hub:windows-${{ steps.buildParameters.outputs.repoVersionFull }} `
-                --build-arg baseImage=unityci/base:windows-${{ steps.buildParameters.outputs.repoVersionFull }} `
-                --build-arg version=${{ steps.buildParameters.outputs.editorVersion }} `
-                --build-arg changeSet=${{ steps.buildParameters.outputs.changeSet }} `
-                --tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionMinor }} `
-                --tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionMajor }} `
-                --tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionFull }} `
-                --push
+          docker build ./images/windows/editor/ `
+            --build-arg hubImage=unityci/hub:windows-${{ steps.buildParameters.outputs.repoVersionFull }} `
+            --build-arg baseImage=unityci/base:windows-${{ steps.buildParameters.outputs.repoVersionFull }} `
+            --build-arg version=${{ steps.buildParameters.outputs.editorVersion }} `
+            --build-arg changeSet=${{ steps.buildParameters.outputs.changeSet }} `
+            --tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionMinor }} `
+            --tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionMajor }} `
+            --tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionFull }} `
+            --push
           ### Warning: If we once publish latest, we will have to do it forever. Lets not do that unless it's needed ###
           ### Another warning: order is important: We go from specific to unspecific with the exception of the most specific tag which is used to check if the image is already there ###
 
@@ -191,8 +192,8 @@ jobs:
         id: image-digest
         if: ${{ success() }}
         run: |
-              $imageDetails = docker buildx imagetools inspect unityci/editor:windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionFull }} | ConvertFrom-Json
-              echo '::set-output digest=$imageDetails.config.digest'
+          $imageDetails = docker buildx imagetools inspect unityci/editor:windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionFull }} | ConvertFrom-Json
+          echo '::set-output digest=$imageDetails.config.digest'
 
       #################
       #   reporting   #


### PR DESCRIPTION
#### Changes

- Decided to trigger both `ubuntu` and `windows` new editor workflows together. So from now on legacy images are always 2019.2.x or lower, for all base OSes.

Reason is that it reduced complexity in the backend, where we don't have to guarantee multiple workflow dispatches were sent. Goes to idempotence.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
