### PR TITLE
mac-mono: fix x64arm64/x64ARM64 case issue

### DIFF
--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -238,6 +238,16 @@ RUN echo "$version-$module" | grep -q -v '^\(2018\|2019\|2020.1\).*webgl' \
     $UNITY_PATH/Editor/Data/PlaybackEngines/WebGLSupport/BuildTools/Brotli/dist/Brotli-0.4.0-py2.7-macosx-10.10-x86_64.egg
 
 #=======================================================================================
+# [2021.x-mac-mono] x64arm64/x64ARM64 case issue https://github.com/game-ci/unity-builder/issues/320
+#=======================================================================================
+RUN echo "$version-$module" | grep -q -v '^2021.*mac-mono' \
+  && exit 0 \
+  || : \
+  && ln -s \
+    $UNITY_PATH/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations/macos_x64arm64_player_nondevelopment_mono \
+    $UNITY_PATH/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations/macos_x64ARM64_player_nondevelopment_mono
+
+#=======================================================================================
 # [2021.x-linux-il2cpp] lld
 #=======================================================================================
 RUN echo "$version-$module" | grep -q -v '^2021.*linux-il2cpp' \


### PR DESCRIPTION
#### Changes

This PR fixes not being able to build macos x64 + arm64 builds with ubuntu. 

It fixes https://github.com/game-ci/unity-builder/issues/320

This is a bug in Unity, and if/when fixed, this patch should be able to be removed:

https://forum.unity.com/threads/linux-command-line-build-of-macos-has-wrong-mono-path.1200499/

Note, I was able to verify the fix implemented in this PR with a custom docker image:

```
FROM unityci/editor:2021.2.13f1-mac-mono-0
RUN ln -s /opt/unity/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations/macos_x64arm64_player_nondevelopment_mono /opt/unity/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations/macos_x64ARM64_player_nondevelopment_mono
```

I am not sure how to test this PR using the artifacts from the CI.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
