### PR TITLE
feat: [BC] Python 2 for all target platforms

### DIFF
--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get -q update \
  clang \
  cpio \
  lsb-release \
- python3-pip \
- python3-setuptools \
+ python \
+ python-setuptools \
  xvfb \
  xz-utils \
  && apt-get clean \

--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -29,18 +29,18 @@ RUN apt-get -q update \
  clang \
  cpio \
  lsb-release \
- python \
- python-setuptools \
+ python3-pip \
+ python3-setuptools \
  xvfb \
  xz-utils \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
 # Use python3 and pip3 as default
-RUN python --version \
+RUN ln -s /usr/bin/python3 /usr/bin/python \
+ && python --version \
  && ln -s /usr/bin/pip3 /usr/bin/pip \
  && pip --version
-
 # Toolbox
 RUN apt-get -q update \
  && apt-get -q install -y --no-install-recommends --allow-downgrades \

--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -25,8 +25,6 @@ RUN apt-get -q update \
  libnss3 \
  libxtst6 \
  libxss1 \
- build-essential \
- clang \
  cpio \
  lsb-release \
  python \
@@ -54,7 +52,7 @@ RUN apt-get -q update \
  && apt-get -q install -y --no-install-recommends software-properties-common \
  && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
  && apt-get -q install -y --only-upgrade libstdc++6 \
- && add-apt-repository -y --remove ppa:ubuntu-toolchain-r/test \ 
+ && add-apt-repository -y --remove ppa:ubuntu-toolchain-r/test \
  && apt-get -q remove -y --auto-remove software-properties-common \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*

--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -29,12 +29,15 @@ RUN apt-get -q update \
  clang \
  cpio \
  lsb-release \
- python-is-python3 \
  python-setuptools \
  xvfb \
  xz-utils \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
+
+# Use python3 and pip3 as default
+RUN ln -s /usr/bin/python /usr/bin/python3 \
+ && ln -s /usr/bin/pip /usr/bin/pip3
 
 # Toolbox
 RUN apt-get -q update \

--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get -q update \
  clang \
  cpio \
  lsb-release \
+ python \
  python-setuptools \
  xvfb \
  xz-utils \

--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -36,8 +36,8 @@ RUN apt-get -q update \
  && rm -rf /var/lib/apt/lists/*
 
 # Use python3 and pip3 as default
-RUN ln -s /usr/bin/python /usr/bin/python3 \
- && ln -s /usr/bin/pip /usr/bin/pip3
+RUN ln -s /usr/bin/python3 /usr/bin/python \
+ && ln -s /usr/bin/pip3 /usr/bin/pip
 
 # Toolbox
 RUN apt-get -q update \

--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -25,8 +25,12 @@ RUN apt-get -q update \
  libnss3 \
  libxtst6 \
  libxss1 \
+ build-essential \
+ clang \
  cpio \
  lsb-release \
+ python-is-python3 \
+ python-setuptools \
  xvfb \
  xz-utils \
  && apt-get clean \

--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -36,8 +36,9 @@ RUN apt-get -q update \
  && rm -rf /var/lib/apt/lists/*
 
 # Use python3 and pip3 as default
-RUN ln -s /usr/bin/python3 /usr/bin/python \
- && ln -s /usr/bin/pip3 /usr/bin/pip
+RUN python --version \
+ && ln -s /usr/bin/pip3 /usr/bin/pip \
+ && pip --version
 
 # Toolbox
 RUN apt-get -q update \

--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -36,11 +36,6 @@ RUN apt-get -q update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-# Use python3 and pip3 as default
-RUN ln -s /usr/bin/python3 /usr/bin/python \
- && python --version \
- && ln -s /usr/bin/pip3 /usr/bin/pip \
- && pip --version
 # Toolbox
 RUN apt-get -q update \
  && apt-get -q install -y --no-install-recommends --allow-downgrades \

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -199,6 +199,19 @@ RUN echo "$module" | grep -q -v 'webgl' \
   && rm -rf /var/lib/apt/lists/*
 
 #=======================================================================================
+# [webgl, il2cpp] python python-setuptools build-essential clang
+#=======================================================================================
+RUN echo "$module" | grep -q -v '\(webgl\|linux-il2cpp\)' \
+  && exit 0 \
+  || : \
+  && apt-get -q update \
+  && apt-get -q install -y --no-install-recommends --allow-downgrades \
+    build-essential \
+    clang \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+#=======================================================================================
 # [2019.x] libnotify4 libunwind-dev libssl1.0
 #=======================================================================================
 RUN echo "$version" | grep -q -v '^2019.' \

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -173,7 +173,7 @@ RUN echo "$version-$module" | grep -q -vP '^20(?!18).*android' \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   # Accept licenses
-  && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \  
+  && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \
   \
   # Update alias 'unity-editor'
   && { \
@@ -197,29 +197,6 @@ RUN echo "$module" | grep -q -v 'webgl' \
     ffmpeg \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-
-#=======================================================================================
-# [webgl, il2cpp] python python-setuptools build-essential clang
-#=======================================================================================
-RUN echo "$module" | grep -q -v '\(webgl\|linux-il2cpp\)' \
-  && exit 0 \
-  || : \
-  && apt-get -q update \
-  && apt-get -q install -y --no-install-recommends --allow-downgrades \
-    python \
-    python-setuptools \
-    build-essential \
-    clang \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-
-#=======================================================================================
-# [android, ios] python 3 support
-#=======================================================================================
-RUN echo "$module" | grep -q -v '\(android\|ios\)' \
-  && exit 0 \
-  || : \
-  && ln -s /usr/bin/python3 /usr/bin/python
 
 #=======================================================================================
 # [2019.x] libnotify4 libunwind-dev libssl1.0


### PR DESCRIPTION
#### Decision

As core maintainers we've considered all options and we've decided to go with the following solution:

- go back to `python2` for all target platforms (in base image) for `Ubuntu 18.04` for and release `v1.0.0`, **introduce BC**
- when `Ubuntu 20.04` or `22.04` becomes recommended by `Unity`, we move to `python3` and release `v2.0.0`, introducing another BC (we'll need to consider which editor versions will support 20.04)

#### Changes in this PR

Allows using Firebase with all images, by enabling the `python` command, referring to `python3`.

- Removes `python` install from `webgl` and `il2cpp` as ~python3~ python2 is already installed on the ubuntu image.
- ~Add `python-is-python3` to base image (this is available from ubuntu 20.04 on and not desired in ubuntu 18.04)~
- ~Move `build-essential`, `clang`  from the editor image to the base image~
- Move `python-setuptools` from the editor image to the base image
- Cleanup any code that is no longer needed
- [BC] BREAKING CHANGE: `python` will no longer reference `python3` (but `python2`) on iOS and Android target platform images. We believe this will not break existing projects that make use of Firebase SDK.

Fixes: https://github.com/game-ci/docker/issues/100

#### Rationale

##### Status quo 

- ubuntu 18:04 (that we  use in our base image https://github.com/game-ci/docker/blob/4e88219ef1eebfa07934e00275786a7a87c531f5/images/ubuntu/base/Dockerfile#L1) has python2 installed
- webgl  and il2cpp currently use python symlink, assuming  python is python2 https://github.com/game-ci/docker/blob/4e88219ef1eebfa07934e00275786a7a87c531f5/images/ubuntu/editor/Dockerfile#L202
- android and iOS build on the fact that python3 is installed along with the target platform module. They then symlink python to python3 https://github.com/game-ci/docker/blob/4e88219ef1eebfa07934e00275786a7a87c531f5/images/ubuntu/editor/Dockerfile#L222

##### Discussion points

- python symlink always used to be python2 so you could argue that developers will  use /usr/bin/python3  directly,  without the alias.
- In 2012 PEP recommended to put python2 scripts in the shebang in 
 order to stay compatible: "in preparation for an eventual change in the default version of Python, Python 2 only scripts should either be updated to be source compatible with Python 3 or else to use python2 in the shebang line."
- The goals of  Ubuntu were to set python3 as the default and only version in 18.04. They do not seem to have made that goal. Perhaps in 20.04?

##### Our options

- install python2 in base image. Change all current python links to use python2 instead of python3. (downside: breaking change people will need to change their workflow if they were using python assuming  python3)
- install python3 in the base image. Change all current python links to use python3 instead of python2 (maybe except for  WebGL, which broke on first sight) in a forward approach, without breaking changes. (downside: not every image will have the same link yet)
- other?

##### Sources used

- https://askubuntu.com/questions/320996/how-to-make-python-program-command-execute-python-3 (note that some posts  and comments are almost 10 years old)
- Ubuntu python doc from 6~8 years  ago: https://wiki.ubuntu.com/Python/3
- The more updated version of that https://wiki.ubuntu.com/Python
- PEP-0394 https://legacy.python.org/dev/peps/pep-0394/

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [ ] I looked up the package sizes and this shouldn't add much at all, but still need to verify this
- [ ] We'll need to verify that python works as expected still, on `linux-il2cpp` and `webgl`
- [ ] Ideally we'd also check if this fixes the problem with firebase installs
