### PR TITLE
deps: upgrade libstdc++ to support Autodesk FBX SDK for Unity

### DIFF
--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get -q update \
  lsb-release \
  xvfb \
  xz-utils \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # Toolbox
 RUN apt-get -q update \
@@ -41,7 +42,8 @@ RUN apt-get -q update \
  openssh-client \
  wget \
  && git lfs install --system --skip-repo \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # libstdc++6 upgrade
 RUN apt-get -q update \
@@ -50,7 +52,8 @@ RUN apt-get -q update \
  && apt-get -q install -y --only-upgrade libstdc++6 \
  && add-apt-repository -y --remove ppa:ubuntu-toolchain-r/test \ 
  && apt-get -q remove -y --auto-remove software-properties-common \
- && apt-get clean
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # Disable default sound card, which removes ALSA warnings
 RUN /bin/echo -e 'pcm.!default {\n\

--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -43,6 +43,15 @@ RUN apt-get -q update \
  && git lfs install --system --skip-repo \
  && apt-get clean
 
+# libstdc++6 upgrade
+RUN apt-get -q update \
+ && apt-get -q install -y --no-install-recommends software-properties-common \
+ && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+ && apt-get -q install -y --only-upgrade libstdc++6 \
+ && add-apt-repository -y --remove ppa:ubuntu-toolchain-r/test \ 
+ && apt-get -q remove -y --auto-remove software-properties-common \
+ && apt-get clean
+
 # Disable default sound card, which removes ALSA warnings
 RUN /bin/echo -e 'pcm.!default {\n\
     type plug\n\

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -266,3 +266,16 @@ RUN echo "$version-$module" | grep -q -v '^2021.*linux-il2cpp' \
     lld \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+#=======================================================================================
+# [2021.x] libstdc++ 6 upgrade
+#=======================================================================================
+RUN echo "$version" | grep -q -v '^2021.' \
+  && exit 0 \
+  || : \
+  && apt-get -q update \
+  && apt-get -q install -y software-properties-common \
+  && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+  && apt-get -y install --only-upgrade libstdc++6 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -266,16 +266,3 @@ RUN echo "$version-$module" | grep -q -v '^2021.*linux-il2cpp' \
     lld \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-
-#=======================================================================================
-# [2021.x] libstdc++ 6 upgrade
-#=======================================================================================
-RUN echo "$version" | grep -q -v '^2021.' \
-  && exit 0 \
-  || : \
-  && apt-get -q update \
-  && apt-get -q install -y software-properties-common \
-  && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
-  && apt-get -y install --only-upgrade libstdc++6 \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
#### Changes

`com.autodesk.fbx@4.1` requires `libstdc++ 6.0.28+` (see https://docs.unity3d.com/Packages/com.autodesk.fbx@4.1/manual/index.html)

Unfortunately the version of `libstdc++` that comes with Ubuntu 18 is `6.0.25`. Until the base images are updated to use Ubuntu 20 (which has a much newer version), we need to install an update `libstdc++`.

I was able to make a docker image: 

```
FROM unityci/editor:2021.2.15f1-linux-il2cpp-0
RUN apt-get update && apt-get -y install software-properties-common && add-apt-repository -y ppa:ubuntu-toolchain-r/test && apt-get -y install --only-upgrade libstdc++6
```

This was tested at:

https://github.com/freezy/VisualPinball.Engine/pull/387#issuecomment-1066182772
 
#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
