### PR TITLE
fix: broken module matching for server builds

### DIFF
--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -24,11 +24,11 @@ RUN for mod in $module; do \
 	# Set execute permissions for modules
 	&& chmod -R 755 /opt/unity/editors/$version/Editor/Data/PlaybackEngines
 
-RUN echo "$version-$module" | grep -q -P '^(2018|2019|2020|2021.1|2021.2.[0-4](?![0-9])).*linux' \
+RUN echo "$version-$module" | grep -q -vP '^(?!(2018|2019|2020|2021.1|2021.2.[0-4](?![0-9])).*linux)' \
   && exit 0 \
   || unity-hub install-modules --version "$version" --module "linux-server" --childModules | tee /var/log/install-module-linux-server.log && grep 'Missing module' /var/log/install-module-linux-server.log | exit $(wc -l);
 
-RUN echo "$version-$module" | grep -q -P '^(2018|2019|2020|2021.1|2021.2.[0-4](?![0-9])).*windows' \
+RUN echo "$version-$module" | grep -q -vP '^(?!(2018|2019|2020|2021.1|2021.2.[0-4](?![0-9])).*windows)' \
   && exit 0 \
   || unity-hub install-modules --version "$version" --module "windows-server" --childModules | tee /var/log/install-module-windows-server.log && grep 'Missing module' /var/log/install-module-windows-server.log | exit $(wc -l);
 

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -24,11 +24,11 @@ RUN for mod in $module; do \
 	# Set execute permissions for modules
 	&& chmod -R 755 /opt/unity/editors/$version/Editor/Data/PlaybackEngines
 
-RUN echo "$version-$module" | grep -q -v '^\(2021.2\|2021.3\|2022\).*linux' \
+RUN echo "$version-$module" | grep -q -P '^(2018|2019|2020|2021.1|2021.2.[0-4](?![0-9])).*linux' \
   && exit 0 \
   || unity-hub install-modules --version "$version" --module "linux-server" --childModules | tee /var/log/install-module-linux-server.log && grep 'Missing module' /var/log/install-module-linux-server.log | exit $(wc -l);
 
-RUN echo "$version-$module" | grep -q -v '^\(2021.2\|2021.3\|2022\).*windows' \
+RUN echo "$version-$module" | grep -q -P '^(2018|2019|2020|2021.1|2021.2.[0-4](?![0-9])).*windows' \
   && exit 0 \
   || unity-hub install-modules --version "$version" --module "windows-server" --childModules | tee /var/log/install-module-windows-server.log && grep 'Missing module' /var/log/install-module-windows-server.log | exit $(wc -l);
 

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -24,11 +24,11 @@ RUN for mod in $module; do \
 	# Set execute permissions for modules
 	&& chmod -R 755 /opt/unity/editors/$version/Editor/Data/PlaybackEngines
 
-RUN echo "$version-$module" | grep -q -vP '^(?!(2018|2019|2020|2021.1|2021.2.[0-4](?![0-9])).*linux)' \
+RUN echo "$version-$module" | grep -q -vP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|20[3-9]).*linux' \
   && exit 0 \
   || unity-hub install-modules --version "$version" --module "linux-server" --childModules | tee /var/log/install-module-linux-server.log && grep 'Missing module' /var/log/install-module-linux-server.log | exit $(wc -l);
 
-RUN echo "$version-$module" | grep -q -vP '^(?!(2018|2019|2020|2021.1|2021.2.[0-4](?![0-9])).*windows)' \
+RUN echo "$version-$module" | grep -q -vP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|20[3-9]).*windows' \
   && exit 0 \
   || unity-hub install-modules --version "$version" --module "windows-server" --childModules | tee /var/log/install-module-windows-server.log && grep 'Missing module' /var/log/install-module-windows-server.log | exit $(wc -l);
 


### PR DESCRIPTION
#### Context

Because the server build target platforms for windows and linux were introduced in 2021.2.5 and we didn't account for the first 4 versions of 2021.2, the following versions failed to build:

- 2021.2.1 linux-il2cpp
- 2021.2.1 windows
- 2021.2.2 linux-il2cpp
- 2021.2.2 windows
- 2021.2.3 linux-il2cpp
- 2021.2.3 windows
- 2021.2.4 linux-il2cpp
- 2021.2.4 windows

![image](https://user-images.githubusercontent.com/20756439/159372953-be901f4b-9d44-46b9-9749-fedd8bcb1855.png)

#### Changes

- Fix regex to only match versions of Editor that support server build platforms.

**Proof**

- Regex101: https://regex101.com/r/AQO7ys/2

- Inside base image: 

```bash
# echo "2021.2.1-macos" | grep -vP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|20[3-9]).*linux'
2021.2.1-macos
# echo "2021.2.1-linux" | grep -vP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|20[3-9]).*linux'
2021.2.1-linux
# echo "2021.2.5-macos" | grep -vP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|20[3-9]).*linux'
2021.2.5-macos
# echo "2021.2.5-linux" | grep -vP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|20[3-9]).*linux'
# echo "2021.2.12-macos" | grep -vP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|20[3-9]).*linux'
2021.2.12-macos
# echo "2021.2.12-linux" | grep -vP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|20[3-9]).*linux'
#
```

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
