### PR TITLE
Fix x64arm64 / x64ARM64 Case Issue in 2022.x

### DIFF
--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -228,9 +228,9 @@ RUN echo "$version-$module" | grep -q -v '^\(2018\|2019\|2020.1\).*webgl' \
     $UNITY_PATH/Editor/Data/PlaybackEngines/WebGLSupport/BuildTools/Brotli/dist/Brotli-0.4.0-py2.7-macosx-10.10-x86_64.egg
 
 #=======================================================================================
-# [2021.x-mac-mono] x64arm64/x64ARM64 case issue https://github.com/game-ci/unity-builder/issues/320
+# [2021.x/2022.x-mac-mono] x64arm64/x64ARM64 case issue https://github.com/game-ci/unity-builder/issues/320
 #=======================================================================================
-RUN echo "$version-$module" | grep -q -v '^2021.*mac-mono' \
+RUN echo "$version-$module" | grep -q -v '^202[12].*mac-mono' \
   && exit 0 \
   || : \
   && ln -s \


### PR DESCRIPTION
#### Changes
This PR is for building MacOS mono builds with ubuntu using Unity Editor `2022.x`.
Unfortunately, the issue [#320](https://github.com/game-ci/unity-builder/issues/320) still exists in Unity Editor `2022.x`.  FYI, I've raised a ticket for this issue to Unity Support team today, so let's hope it gets resolved.


#### Checklist
- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or **not needed**)
- [x] Verify the fix in this PR with a custom docker image: `shirokurohitsuji/unityci-editor`