### PR TITLE
Add blender to base image to enable seamless FBX import from .blend project files

### DIFF
--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get -q update \
  python-setuptools \
  xvfb \
  xz-utils \
+ blender \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
#### Changes

- Adds blender to gameci image, to enable auto FBX import from .blend files ([unity docs](https://docs.unity3d.com/Manual/HOWTO-ImportObjectsFrom3DApps.html#Blender)).

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
