### PR TITLE
chore: free up more disk space

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,8 +1,7 @@
 name: PR 😎
 
 on:
-  push: {}
-#  pull_request_target: {}
+  pull_request_target: {}
 
 jobs:
   reportingTest:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,6 +1,7 @@
 name: PR 😎
 
 on:
+  push: {}
   pull_request_target: {}
 
 jobs:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -122,16 +122,6 @@ jobs:
           # - monodevelop # MonoDevelop / Unity Debugger
 
     steps:
-      #######################
-      #   Free disk space   #
-      #######################
-      - name: Maximize build disk space
-        uses: easimon/maximize-build-space@v6
-        with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-
       #############
       #   Setup   #
       #############
@@ -152,6 +142,12 @@ jobs:
             ${{ runner.os }}-buildx-pr-${{ matrix.targetPlatform }}
             ${{ runner.os }}-buildx-${{ matrix.targetPlatform }}
             ${{ runner.os }}-buildx-
+
+      #######################
+      #   Free disk space   #
+      #######################
+      - name: Free disk space
+        run: .github/workflows/scripts/free_disk_space.sh
 
       ##################
       #   Base image   #

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -2,7 +2,7 @@ name: PR 😎
 
 on:
   push: {}
-  pull_request_target: {}
+#  pull_request_target: {}
 
 jobs:
   reportingTest:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -121,6 +121,16 @@ jobs:
           # - monodevelop # MonoDevelop / Unity Debugger
 
     steps:
+      #######################
+      #   Free disk space   #
+      #######################
+      - name: Maximize build disk space
+        uses: easimon/maximize-build-space@v6
+        with:
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+
       #############
       #   Setup   #
       #############
@@ -141,12 +151,6 @@ jobs:
             ${{ runner.os }}-buildx-pr-${{ matrix.targetPlatform }}
             ${{ runner.os }}-buildx-${{ matrix.targetPlatform }}
             ${{ runner.os }}-buildx-
-
-      #######################
-      #   Free disk space   #
-      #######################
-      - name: Free disk space
-        run: .github/workflows/scripts/free_disk_space.sh
 
       ##################
       #   Base image   #
@@ -234,6 +238,7 @@ jobs:
       #   Free disk space   #
       #######################
       # TODO: Determine what we can free on windows
+
       ##################
       #   Base image   #
       ##################

--- a/.github/workflows/scripts/free_disk_space.sh
+++ b/.github/workflows/scripts/free_disk_space.sh
@@ -7,12 +7,17 @@ echo "Freeing up disk space on CI system"
 echo "=============================================================================="
 
 # Before
+echo ""
 echo "Disk space before:"
 df -h
 
-#echo "Listing 100 largest packages"
-#dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
-#echo "Removing large packages"
+# List packages
+echo "Listing 25 largest packages"
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 25
+
+# Remove packages
+echo ""
+echo "Removing large packages"
 sudo apt-get remove -y '^ghc-8.*'
 #sudo apt-get remove -y '^dotnet-.*'
 #sudo apt-get remove -y '^llvm-.*'
@@ -20,16 +25,25 @@ sudo apt-get remove -y 'php.*'
 #sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
 sudo apt-get autoremove -y
 sudo apt-get clean
+echo ""
+echo "Disk space after apt-get:"
 df -h
 
+# Large dirs
 echo "Removing large directories"
 # https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
-rm -rf /usr/share/dotnet/
+sudo rm -rf /usr/share/dotnet
+sudo rm -rf /usr/local/lib/android
+sudo rm -rf /opt/ghc
+echo ""
+echo "Disk space after removing large directories:"
+df -h
 
 # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
-rm -rf "/usr/local/share/boost"
-rm -rf "$AGENT_TOOLSDIRECTORY"
+sudo rm -rf "/usr/local/share/boost"
+sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
 # After
+echo ""
 echo "Disk space after:"
 df -h

--- a/.github/workflows/scripts/free_disk_space.sh
+++ b/.github/workflows/scripts/free_disk_space.sh
@@ -10,7 +10,6 @@ echo ""
 # Before
 echo "Disk space before:"
 df -h
-echo ""
 
 # List packages
 #echo "Listing 25 largest packages"
@@ -30,7 +29,6 @@ echo ""
 #echo ""
 #echo "Disk space after apt-get:"
 #df -h
-#echo ""
 
 # Large dirs
 echo "Removing large directories"
@@ -41,14 +39,13 @@ sudo rm -rf /opt/ghc
 echo ""
 echo "Disk space after removing large directories:"
 df -h
-echo ""
 
 # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
+echo "Removing preinstalled tools"
 sudo rm -rf "/usr/local/share/boost"
 sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 echo ""
 
 # After
-echo ""
 echo "Disk space after:"
 df -h

--- a/.github/workflows/scripts/free_disk_space.sh
+++ b/.github/workflows/scripts/free_disk_space.sh
@@ -5,29 +5,32 @@
 echo "=============================================================================="
 echo "Freeing up disk space on CI system"
 echo "=============================================================================="
+echo ""
 
 # Before
-echo ""
 echo "Disk space before:"
 df -h
+echo ""
 
 # List packages
-echo "Listing 25 largest packages"
-dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 25
+#echo "Listing 25 largest packages"
+#dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 25
+#echo ""
 
 # Remove packages
-echo ""
-echo "Removing large packages"
-sudo apt-get remove -y '^ghc-8.*'
+#echo ""
+#echo "Removing large packages"
+#sudo apt-get remove -y '^ghc-8.*'
 #sudo apt-get remove -y '^dotnet-.*'
 #sudo apt-get remove -y '^llvm-.*'
-sudo apt-get remove -y 'php.*'
+#sudo apt-get remove -y 'php.*'
 #sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
-sudo apt-get autoremove -y
-sudo apt-get clean
-echo ""
-echo "Disk space after apt-get:"
-df -h
+#sudo apt-get autoremove -y
+#sudo apt-get clean
+#echo ""
+#echo "Disk space after apt-get:"
+#df -h
+#echo ""
 
 # Large dirs
 echo "Removing large directories"
@@ -38,10 +41,12 @@ sudo rm -rf /opt/ghc
 echo ""
 echo "Disk space after removing large directories:"
 df -h
+echo ""
 
 # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
 sudo rm -rf "/usr/local/share/boost"
 sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+echo ""
 
 # After
 echo ""


### PR DESCRIPTION
#### Changes

- Free up more disk space in order to keep building android images of increasing size.
- Tried [easimon/maximize-build-space](https://github.com/easimon/maximize-build-space) action, but it broke docker buildx :(
- Follow-up of https://github.com/game-ci/docker/issues/185
- Intends to solve the following errors ([source](https://github.com/game-ci/docker/actions/runs/3204995537)):
![image](https://user-images.githubusercontent.com/20756439/194591012-698cb2f4-9ba0-42b4-a8a6-4e2a0e3fab3a.png)
- This frees up 49GB which is 7GB more than before
![image](https://user-images.githubusercontent.com/20756439/194601550-92378059-c15e-407c-9066-706b845ff759.png)


> 🛠 Build unityci/editor (android)
> buildx failed with: ERROR: failed to solve: failed to create temp dir: mkdir /tmp/containerd-mount4174648361: no space left on device
> 🛠 Build unityci/editor (android)
> buildx failed with: ERROR: failed to solve: error writing layer blob: failed to copy: failed to send write: write /tmp/.buildx-cache/ingest/0f0bc1dd60a20fda07ae9701b1ef8e482235bde20ec2cc2c8af4597e0af6ff53/data: no space left on device: unknown
> 🛠 Build unityci/editor (android)
> You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 73 MB



#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme (updated or not needed)
