### PR TITLE
mac-mono: fix x64arm64/x64ARM64 case issue for dev builds

### DIFF
--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -235,7 +235,10 @@ RUN echo "$version-$module" | grep -q -v '^202[12].*mac-mono' \
   || : \
   && ln -s \
     $UNITY_PATH/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations/macos_x64arm64_player_nondevelopment_mono \
-    $UNITY_PATH/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations/macos_x64ARM64_player_nondevelopment_mono
+    $UNITY_PATH/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations/macos_x64ARM64_player_nondevelopment_mono \
+  && ln -s \
+    $UNITY_PATH/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations/macos_x64arm64_player_development_mono \
+    $UNITY_PATH/Editor/Data/PlaybackEngines/MacStandaloneSupport/Variations/macos_x64ARM64_player_development_mono
 
 #=======================================================================================
 # [2021.x-linux-il2cpp] lld


### PR DESCRIPTION
#### Changes

This PR fixes the case issue that occurs in development builds (via the `-Development` flag) like #158 did for release builds.

#### Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
