### PR TITLE
Add zip and unzip to the base image

### DIFF
--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -44,6 +44,8 @@ RUN apt-get -q update \
  jq \
  openssh-client \
  wget \
+ zip \
+ unzip \
  && git lfs install --system --skip-repo \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -111,8 +111,6 @@ RUN echo "$version-$module" | grep -q -v '^\(2018.3\|2018.4\).*android' \
   && export PATH=$JAVA_HOME/bin:${ANDROID_SDK_ROOT}/tools:${ANDROID_SDK_ROOT}/tools/bin:${ANDROID_SDK_ROOT}/platform-tools:${PATH} \
   \
   # Download Android SDK (commandline tools) 26.1.1
-  && apt-get update -qq \
-  && apt-get install -qq -y --no-install-recommends unzip \
   && mkdir -p ${ANDROID_SDK_ROOT} \
   && chmod -R 777 ${ANDROID_INSTALL_LOCATION} \
   && wget -q https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip -O /tmp/android-sdk.zip \
@@ -127,11 +125,6 @@ RUN echo "$version-$module" | grep -q -v '^\(2018.3\|2018.4\).*android' \
   \
   # Accept licenses
   && yes | "${ANDROID_HOME}/tools/bin/sdkmanager" --licenses \
-  \
-  # Clean up
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* \
-  && rm -rf /tmp/* \
   \
   # Update alias 'unity-editor'
   && { \

--- a/images/windows/hub/Dockerfile
+++ b/images/windows/hub/Dockerfile
@@ -1,7 +1,6 @@
 ARG baseImage="unityci/base:windows-latest"
 
 FROM $baseImage
-ARG hubVersion="3.0.0"
 
 # Install unity hub
-RUN choco install unity-hub --version=%hubVersion --no-progress -y
+RUN choco install unity-hub --no-progress -y

--- a/images/windows/hub/Dockerfile
+++ b/images/windows/hub/Dockerfile
@@ -1,6 +1,7 @@
 ARG baseImage="unityci/base:windows-latest"
 
 FROM $baseImage
+ARG hubVersion="3.0.0"
 
 # Install unity hub
-RUN choco install unity-hub --no-progress -y
+RUN choco install unity-hub --version=%hubVersion --no-progress -y


### PR DESCRIPTION
#### Changes

- Add zip and unzip to the base image (1205 kB) as some Unity packages leverage it for working with Android libraries. 

One example is Microsoft App Center for Unity as it uses it to unzip aar's for Android builds to modify settings within the aar before rezipping it for the build process. The editor install docker image also utilizes unzip for certain Android setup steps. 

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
