### PR TITLE
Default hubVersion for ubuntu hub image bumped from 3.4.2-beta.1 to 3.4.2

### DIFF
--- a/images/ubuntu/hub/Dockerfile
+++ b/images/ubuntu/hub/Dockerfile
@@ -1,6 +1,6 @@
 ARG baseImage="unityci/base"
 FROM $baseImage
-ARG hubVersion="3.4.2-beta.1"
+ARG hubVersion="3.4.2"
 
 # Hub dependencies
 RUN apt-get -q update \


### PR DESCRIPTION
#### Changes
- Changed default hub version in ubuntu Dockerfile to `3.4.2`, which was [released on April 17th](https://unity.com/unity-hub/release-notes). This version of the Unity Hub has a fix for the wrong android module dependencies (OpenJDK, Android SDK and NDK), so this small change fixes https://github.com/game-ci/docker/issues/202 and fixes https://github.com/game-ci/unity-builder/issues/489

I tested recreating the android image on my end with this version of the Unity Hub and I could successfully build an .apk for a game that is using Unity 2022.2.17f1, and was failing with the old image. I also explicitly checked for the OpenJDK version downloaded by Unity Hub for this Unity version, and it is correct:

```
/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/OpenJDK/bin/java -version
openjdk version "11.0.14.1" 2022-02-08
OpenJDK Runtime Environment Temurin-11.0.14.1+1 (build 11.0.14.1+1)
OpenJDK 64-Bit Server VM Temurin-11.0.14.1+1 (build 11.0.14.1+1, mixed mode)
```

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (not needed)

Please tell me if something else is expected from my side, as this is my first pull request here and I might be missing something :smile:  And I also want to seize the opportunity to thank you one thousand times for this amazing project!