### PR TITLE
Add a non-root user

### DIFF
--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -74,3 +74,12 @@ RUN echo "576562626572264761624c65526f7578" > /etc/machine-id && mkdir -p /var/l
 
 # Used by Unity editor in "modules.json" and must not end with a slash.
 ENV UNITY_PATH="/opt/unity"
+
+# create a user for non-root operation
+ARG USER="player1"
+RUN useradd -ms /bin/bash $USER && \
+        usermod -aG sudo $USER && \
+        echo "$USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
+        mkdir -p /home/$USER/.local/bin && \
+        mkdir -p /home/$USER/.local/lib && \
+        chown -R $USER:$USER /home/$USER/

--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -76,7 +76,7 @@ RUN echo "576562626572264761624c65526f7578" > /etc/machine-id && mkdir -p /var/l
 ENV UNITY_PATH="/opt/unity"
 
 # create a user for non-root operation
-ARG USER="player1"
+ARG USER="gameci"
 RUN useradd -ms /bin/bash $USER && \
         usermod -aG sudo $USER && \
         echo "$USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
@@ -84,5 +84,3 @@ RUN useradd -ms /bin/bash $USER && \
         mkdir -p /home/$USER/.local/lib && \
         chown -R $USER:$USER /home/$USER/
 
-USER $USER
-WORKDIR /home/$USER/

--- a/images/ubuntu/base/Dockerfile
+++ b/images/ubuntu/base/Dockerfile
@@ -83,3 +83,6 @@ RUN useradd -ms /bin/bash $USER && \
         mkdir -p /home/$USER/.local/bin && \
         mkdir -p /home/$USER/.local/lib && \
         chown -R $USER:$USER /home/$USER/
+
+USER $USER
+WORKDIR /home/$USER/

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -312,3 +312,6 @@ RUN echo "$version-$module" | grep -q -v '^2021.*linux-il2cpp' \
     lld \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+USER gameci
+WORKDIR /home/gameci/


### PR DESCRIPTION
#### Changes

adds a non root user `gameci` to the docker images.

This resolves an issue where Unity Editor will prompt the user with a confirmation screen to allow `root` to run Unity. This doesn't affect jobs running with batch-mode, but it prevents the screen from being able to be recorded or viewed during GPU-enabled runs.
