### PR TITLE
Fix windows builds

### DIFF
--- a/images/windows/editor/Dockerfile
+++ b/images/windows/editor/Dockerfile
@@ -59,9 +59,7 @@ COPY --from=Builder ["C:/UnityEditor/", "C:/UnityEditor/"]
 
 # Need to grab these dependencies that the editor needs to run
 COPY --from=Builder C:/windows/system32/MSVCP100.dll \
-                    C:/windows/system32/MSVCP120.dll \
                     C:/windows/system32/MSVCR100.dll \
-                    C:/windows/system32/MSVCR120.dll \
                     C:/windows/system32/
 
 # Add version to file at editor path


### PR DESCRIPTION
#### Changes

- Remove MSVCP120.ddl and MSVCR120.dll from unityci/editor:windows-* Dockerfile

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows Unity editor image to no longer include certain DLL dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->