### PR TITLE
fix: "No sdkmanager found" in 6000.x Android

### DIFF
--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -181,6 +181,7 @@ RUN echo "$version-$module" | grep -q -vP '^(202[1-9]|[6-9][0-9]{3}|[1-9][0-9]{4
   && . ~/.bashrc \
   && export ESCAPED_UNITY_PATH=$(printf '%s' "$UNITY_PATH" | sed 's/[#\/]/\\\0/g') \
   && export RAW_ANDROID_SDK_ROOT=$(jq -cr '(.[] | select(.id | contains("android-sdk-platform-tools")) | .destination) // (.[] | select(.id | contains("android-sdk-ndk-tools")) | .destination)' $UNITY_PATH/modules.json) \
+  && export ANDROID_SDK_ROOT=$(echo $RAW_ANDROID_SDK_ROOT | sed -e "s/{UNITY_PATH}/$ESCAPED_UNITY_PATH/g") \
   && export ANDROID_HOME=${ANDROID_SDK_ROOT} \
   && export RAW_ANDROID_NDK_ROOT=$(jq -cr '(.[] | select(.id | contains("android-ndk"))).destination' $UNITY_PATH/modules.json) \
   && export ANDROID_NDK_HOME=$(echo $RAW_ANDROID_NDK_ROOT | sed -e "s/{UNITY_PATH}/$ESCAPED_UNITY_PATH/g") \


### PR DESCRIPTION
#### Changes
https://github.com/game-ci/unity-builder/issues/746 

The 'module.json' has some changes with the latest security patch applied with 6000.0.58f2
this causes the line `RAW_ANDROID_SDK_ROOT=$(jq -cr '(.[] | select(.id | contains("android-sdk-platform-tools"))).destination' $UNITY_PATH/modules.json); \` Not finding the entry, which in turn causes `ANDROID_HOME` and `ANDROID_SDK_ROOT` not to be set properly.

This does indeed make the environmental be set, but it does not change the fact that this doesn't work.

thanks to a pointer from @adabru, It seems like the android-sdk-platform-tools is missing from the image, and after adding installing those separately fixes that issue.

Seems to work now, It managed to build an APK from an empty project.
I have built an image with this change in. Updated with the latest.

https://hub.docker.com/r/marinov86/unity-editor

#### Checklist

Ran the builds again to verify the new changes work.

## 6000.0.59f2
```
docker run --rm editor:6000.0.59f2_test bash -lc 'cat /bin/unity-editor.d/android-2019+.sh'
> export ANDROID_SDK_ROOT=/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/SDK
> export ANDROID_HOME=/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/SDK
> export ANDROID_NDK_HOME=/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/NDK
> export JAVA_HOME=/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/OpenJDK
> export ANDROID_CMDLINE_TOOLS_PATH=/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/cmdline-tools/16.0
> export PATH=/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/OpenJDK/bin:/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/cmdline-tools/16.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

```
docker run --rm editor:6000.0.59f2_test bash -lc 'ls -m /opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/SDK'
> build-tools, cmake, cmdline-tools, licenses, platform-tools, platforms, tools
```

## 6000.0.58f1

Note: This version succeeded prior to the changes made with the Security patch, that contained the "android-sdk-platform-tools" in modules.json as well as installed platform tools.

```
docker run --rm editor:6000.0.58f1_test bash -lc 'cat /bin/unity-editor.d/android-2019+.sh'
> export ANDROID_SDK_ROOT=/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/SDK
> export ANDROID_HOME=/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/SDK
> export ANDROID_NDK_HOME=/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/NDK
> export JAVA_HOME=/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/OpenJDK
> export ANDROID_CMDLINE_TOOLS_PATH=/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/cmdline-tools/16.0
> export PATH=/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/OpenJDK/bin:/opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/SDK/cmdline-tools/16.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

```
```
docker run --rm editor:6000.0.58f1_test bash -lc 'ls -m /opt/unity/Editor/Data/PlaybackEngines/AndroidPlayer/SDK'
> build-tools, cmake, cmdline-tools, licenses, platform-tools, platforms, tools
```


- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically installs Android platform-tools when missing, with version-aware conditions to avoid unnecessary installs.
* **Bug Fixes**
  * More reliable detection of Android SDK location using a fallback between multiple sources.
  * Ensures consistent setup of PATH and Android-related environment variables (ANDROID_SDK_ROOT, ANDROID_HOME, ANDROID_NDK_HOME, JAVA_HOME).
* **Chores**
  * Added clearly labeled sections for Android platform-tools installation steps to improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->