### PR TITLE
feat: add manual cleanup workflow for stuck builds

### DIFF
--- a/.github/workflows/clean-up-stuck-builds.yml
+++ b/.github/workflows/clean-up-stuck-builds.yml
@@ -1,0 +1,36 @@
+name: Clean Up Stuck Builds
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "yes" to confirm cleanup of all stuck builds'
+        required: true
+        default: ''
+
+jobs:
+  cleanup:
+    name: Clean up stuck builds
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.confirm == 'yes' }}
+    steps:
+      - name: Trigger manual cleanup
+        run: |
+          echo "Triggering manual cleanup of stuck builds..."
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+            -H "Authorization: Bearer ${{ secrets.VERSIONING_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            "https://europe-west3-unity-ci-versions.cloudfunctions.net/cleanUpStuckBuilds")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | head -n -1)
+
+          echo "HTTP Status: $HTTP_CODE"
+          echo "$BODY" | jq . 2>/dev/null || echo "$BODY"
+
+          if [ "$HTTP_CODE" -ne 200 ]; then
+            echo "::error::Cleanup request failed with status $HTTP_CODE"
+            exit 1
+          fi
+
+          echo "::notice::Cleanup completed successfully"


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` triggered workflow that maintainers can use from the **Actions tab** to manually clean up all stuck builds.

## How to use

1. Go to **Actions** → **Clean Up Stuck Builds**
2. Click **Run workflow**
3. Type `yes` in the confirmation field
4. Click **Run workflow**

The workflow calls the versioning backend's `cleanUpStuckBuilds` endpoint, which:
- Finds all builds with status `"started"`
- Checks DockerHub for each one (using the V2 API)
- Marks them as **published** if the image exists, or **failed** (for automatic retry) if it doesn't
- Returns a summary of actions taken

## Why

When builds get stuck in `"started"` status (e.g. after the digest extraction bug, or a reporting failure), the automated cleaner only processes 5 per run and waits 6 hours. This workflow processes **all** stuck builds immediately.

## Dependencies

Requires [game-ci/versioning-backend#82](https://github.com/game-ci/versioning-backend/pull/82) to be deployed first (adds the `cleanUpStuckBuilds` endpoint and V2 DockerHub API).

## Test plan

- [ ] Deploy versioning-backend PR #82
- [ ] Merge this PR
- [ ] Trigger the workflow from Actions tab with `yes` confirmation
- [ ] Verify stuck builds are cleaned up in the response output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new workflow for automated cleanup of stuck builds that can be triggered manually with confirmation, providing status feedback upon completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->