### PR TITLE
Handle duplicate build dispatches gracefully

### DIFF
--- a/.github/workflows/actions/report-to-backend/index.js
+++ b/.github/workflows/actions/report-to-backend/index.js
@@ -54,6 +54,12 @@ const action = async () => {
       const { statusCode, data } = await post(startedEndpoint, { headers, body });
       console.log('Reported that this build has started.', statusCode, data);
     } catch (err) {
+      // 409 means the build is already in progress or published (duplicate dispatch).
+      // Exit gracefully so the workflow does not trigger the "Report failure" step.
+      if (err.statusCode === 409) {
+        core.warning(`Duplicate dispatch: ${err.data || 'build already exists'}. Exiting gracefully.`);
+        process.exit(0);
+      }
       console.error('An error occurred while reporting the start of this build.', err.statusCode, err.message);
       console.error('~> data:', err.data);
       core.setFailed(err)


### PR DESCRIPTION
## Summary

When the Ingeminator dispatches retries, two workflows can run simultaneously for the same build. The backend now returns **409 Conflict** for duplicate dispatches (see game-ci/versioning-backend#84), but the `report-to-backend` action was treating any non-2xx as an error — calling `core.setFailed()`, which triggers the "Report failure" step and marks the in-progress build back to "failed".

This fix makes the action handle 409 gracefully: log a warning and exit cleanly via `process.exit(0)`, so the workflow does not trigger "Report failure" for duplicate dispatches.

**Without this fix**, the retry loop can still occur:
1. Run A reports build start → 200 → starts building
2. Run B reports build start → 409 → `setFailed()` → "Report failure" runs → marks build as "failed"
3. Run A is still building but the build is now "failed" in the backend
4. Ingeminator dispatches another retry → loop continues

**With this fix**, Run B exits cleanly on 409 and the "Report failure" step never runs.

## Test plan

- [ ] Verify duplicate dispatch workflows exit with a warning instead of failing
- [ ] Confirm no "Report failure" step runs for duplicate dispatches
- [ ] Monitor that retry loops stop completely

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in the backend reporting workflow to improve system robustness. Specific error conditions that previously caused the workflow to fail are now managed gracefully, allowing successful operation completion. This provides more reliable CI/CD pipeline behavior and eliminates false-positive failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->