### PR TITLE
Add manual workflow to reset failed builds at max retries

### DIFF
--- a/.github/workflows/reset-failed-builds.yml
+++ b/.github/workflows/reset-failed-builds.yml
@@ -1,0 +1,50 @@
+name: Reset Failed Builds
+
+on:
+  workflow_dispatch:
+    inputs:
+      buildId:
+        description: 'Optional: specific build ID to reset (leave empty to reset ALL maxed-out builds)'
+        required: false
+        default: ''
+      confirm:
+        description: 'Type "yes" to confirm reset of failure counts'
+        required: true
+        default: ''
+
+jobs:
+  reset:
+    name: Reset failed build counts
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.confirm == 'yes' }}
+    steps:
+      - name: Reset failure counts
+        run: |
+          BUILD_ID="${{ github.event.inputs.buildId }}"
+
+          if [ -n "$BUILD_ID" ]; then
+            echo "Resetting failure count for build: $BUILD_ID"
+            PAYLOAD="{\"buildId\": \"$BUILD_ID\"}"
+          else
+            echo "Resetting ALL failed builds at max retries..."
+            PAYLOAD="{}"
+          fi
+
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+            -H "Authorization: Bearer ${{ secrets.VERSIONING_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "https://europe-west3-unity-ci-versions.cloudfunctions.net/resetFailedBuilds")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | head -n -1)
+
+          echo "HTTP Status: $HTTP_CODE"
+          echo "$BODY" | jq . 2>/dev/null || echo "$BODY"
+
+          if [ "$HTTP_CODE" -ne 200 ]; then
+            echo "::error::Reset request failed with status $HTTP_CODE"
+            exit 1
+          fi
+
+          echo "::notice::Reset completed successfully"


### PR DESCRIPTION
## Summary

Add a `workflow_dispatch` workflow that calls the `resetFailedBuilds` backend endpoint (game-ci/versioning-backend#85). Maintainers can trigger it from the Actions tab to reset builds stuck at max failure count.

- **Bulk reset**: leave `buildId` empty to reset all maxed-out builds
- **Single reset**: enter a specific build ID to reset just that build
- Requires typing "yes" to confirm (same safety pattern as `clean-up-stuck-builds.yml`)
- Uses the existing `VERSIONING_TOKEN` secret

## Depends on

- game-ci/versioning-backend#85 — backend `resetFailedBuilds` endpoint

## Test plan

- [ ] Workflow appears in Actions tab with manual trigger
- [ ] Bulk reset: resets all builds with `failureCount >= 15`
- [ ] Single reset: resets only the specified build
- [ ] Fails gracefully if confirmation is not "yes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new manual workflow for resetting failed builds. Supports resetting individual builds or all failed builds simultaneously, with a confirmation requirement for execution safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->