### PR TITLE
fix: prevent false failure reports when image already exists

### DIFF
--- a/.github/workflows/new-ubuntu-base-image-requested.yml
+++ b/.github/workflows/new-ubuntu-base-image-requested.yml
@@ -60,9 +60,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if image does not already exist
         run: |
-          # Source: https://stackoverflow.com/a/39731444/3593896
+          # DockerHub V2 API (V1 was decommissioned, returns 410 Gone)
           function docker_tag_exists() {
-            curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 > /dev/null
+            curl --silent -f -lSL https://hub.docker.com/v2/repositories/$1/tags/$2 > /dev/null
           }
 
           if docker_tag_exists unityci/base ubuntu-${{ github.event.client_payload.repoVersionFull }} ; then

--- a/.github/workflows/new-ubuntu-base-image-requested.yml
+++ b/.github/workflows/new-ubuntu-base-image-requested.yml
@@ -59,6 +59,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if image does not already exist
+        id: check-image
         run: |
           # DockerHub V2 API (V1 was decommissioned, returns 410 Gone)
           function docker_tag_exists() {
@@ -67,6 +68,7 @@ jobs:
 
           if docker_tag_exists unityci/base ubuntu-${{ github.event.client_payload.repoVersionFull }} ; then
             echo "Image already exists. Exiting."
+            echo "image_exists=true" >> $GITHUB_OUTPUT
             exit 1
           fi
       - name: Cache Docker layers
@@ -123,7 +125,7 @@ jobs:
           specificTag: ubuntu-${{ github.event.client_payload.repoVersionFull }}
           digest: ${{ steps.build_ubuntu_base_image.outputs.digest }}
       - name: Report failure
-        if: ${{ failure() || cancelled() }}
+        if: ${{ (failure() || cancelled()) && steps.check-image.outputs.image_exists != 'true' }}
         uses: ./.github/workflows/actions/report-to-backend
         with:
           token: ${{ secrets.VERSIONING_TOKEN }}

--- a/.github/workflows/new-ubuntu-hub-image-requested.yml
+++ b/.github/workflows/new-ubuntu-hub-image-requested.yml
@@ -59,6 +59,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if image does not already exist
+        id: check-image
         run: |
           # DockerHub V2 API (V1 was decommissioned, returns 410 Gone)
           function docker_tag_exists() {
@@ -67,6 +68,7 @@ jobs:
 
           if docker_tag_exists unityci/hub ubuntu-${{ github.event.client_payload.repoVersionFull }} ; then
             echo "Image already exists. Exiting."
+            echo "image_exists=true" >> $GITHUB_OUTPUT
             exit 1
           fi
       - name: Cache Docker layers
@@ -129,7 +131,7 @@ jobs:
           specificTag: ubuntu-${{ github.event.client_payload.repoVersionFull }}
           digest: ${{ steps.build_ubuntu_hub_image.outputs.digest }}
       - name: Report failure
-        if: ${{ failure() || cancelled() }}
+        if: ${{ (failure() || cancelled()) && steps.check-image.outputs.image_exists != 'true' }}
         uses: ./.github/workflows/actions/report-to-backend
         with:
           token: ${{ secrets.VERSIONING_TOKEN }}

--- a/.github/workflows/new-ubuntu-hub-image-requested.yml
+++ b/.github/workflows/new-ubuntu-hub-image-requested.yml
@@ -60,9 +60,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if image does not already exist
         run: |
-          # Source: https://stackoverflow.com/a/39731444/3593896
+          # DockerHub V2 API (V1 was decommissioned, returns 410 Gone)
           function docker_tag_exists() {
-            curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 > /dev/null
+            curl --silent -f -lSL https://hub.docker.com/v2/repositories/$1/tags/$2 > /dev/null
           }
 
           if docker_tag_exists unityci/hub ubuntu-${{ github.event.client_payload.repoVersionFull }} ; then

--- a/.github/workflows/new-ubuntu-legacy-editor-image-requested.yml
+++ b/.github/workflows/new-ubuntu-legacy-editor-image-requested.yml
@@ -74,9 +74,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if image does not already exist
         run: |
-          # Source: https://stackoverflow.com/a/39731444/3593896
+          # DockerHub V2 API (V1 was decommissioned, returns 410 Gone)
           function docker_tag_exists() {
-            curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 > /dev/null
+            curl --silent -f -lSL https://hub.docker.com/v2/repositories/$1/tags/$2 > /dev/null
           }
 
           if docker_tag_exists unityci/editor ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }} ; then

--- a/.github/workflows/new-ubuntu-legacy-editor-image-requested.yml
+++ b/.github/workflows/new-ubuntu-legacy-editor-image-requested.yml
@@ -73,6 +73,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if image does not already exist
+        id: check-image
         run: |
           # DockerHub V2 API (V1 was decommissioned, returns 410 Gone)
           function docker_tag_exists() {
@@ -81,6 +82,7 @@ jobs:
 
           if docker_tag_exists unityci/editor ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }} ; then
             echo "Image already exists. Exiting."
+            echo "image_exists=true" >> $GITHUB_OUTPUT
             exit 1
           fi
       #######################
@@ -183,7 +185,7 @@ jobs:
           specificTag: ubuntu-${{ github.event.client_payload.repoVersionFull }}
           digest: ${{ steps.image-digest.outputs.digest }}
       - name: Report failure
-        if: ${{ failure() || cancelled() }}
+        if: ${{ (failure() || cancelled()) && steps.check-image.outputs.image_exists != 'true' }}
         uses: ./.github/workflows/actions/report-to-backend
         with:
           token: ${{ secrets.VERSIONING_TOKEN }}

--- a/.github/workflows/new-ubuntu-post-2019-2-editor-image-requested.yml
+++ b/.github/workflows/new-ubuntu-post-2019-2-editor-image-requested.yml
@@ -74,9 +74,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if image does not already exist
         run: |
-          # Source: https://stackoverflow.com/a/39731444/3593896
+          # DockerHub V2 API (V1 was decommissioned, returns 410 Gone)
           function docker_tag_exists() {
-            curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 > /dev/null
+            curl --silent -f -lSL https://hub.docker.com/v2/repositories/$1/tags/$2 > /dev/null
           }
 
           if docker_tag_exists unityci/editor ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }} ; then

--- a/.github/workflows/new-ubuntu-post-2019-2-editor-image-requested.yml
+++ b/.github/workflows/new-ubuntu-post-2019-2-editor-image-requested.yml
@@ -73,6 +73,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if image does not already exist
+        id: check-image
         run: |
           # DockerHub V2 API (V1 was decommissioned, returns 410 Gone)
           function docker_tag_exists() {
@@ -81,6 +82,7 @@ jobs:
 
           if docker_tag_exists unityci/editor ubuntu-${{ github.event.client_payload.editorVersion }}-${{ matrix.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }} ; then
             echo "Image already exists. Exiting."
+            echo "image_exists=true" >> $GITHUB_OUTPUT
             exit 1
           fi
       #######################
@@ -183,7 +185,7 @@ jobs:
           specificTag: ubuntu-${{ github.event.client_payload.repoVersionFull }}
           digest: ${{ steps.image-digest.outputs.digest }}
       - name: Report failure
-        if: ${{ failure() || cancelled() }}
+        if: ${{ (failure() || cancelled()) && steps.check-image.outputs.image_exists != 'true' }}
         uses: ./.github/workflows/actions/report-to-backend
         with:
           token: ${{ secrets.VERSIONING_TOKEN }}

--- a/.github/workflows/new-windows-base-image-requested.yml
+++ b/.github/workflows/new-windows-base-image-requested.yml
@@ -122,7 +122,7 @@ jobs:
             param([string] $Repository, [string] $Tag)
 
             Try {
-              Invoke-RestMethod "https://index.docker.io/v1/repositories/$Repository/tags/$Tag"
+              Invoke-RestMethod "https://hub.docker.com/v2/repositories/$Repository/tags/$Tag"
             } Catch {} # Assume image does not exist on erroneous response
 
             return $?

--- a/.github/workflows/new-windows-base-image-requested.yml
+++ b/.github/workflows/new-windows-base-image-requested.yml
@@ -115,6 +115,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
         run: docker login --username $Env:username --password $Env:password
       - name: Check if image does not already exist
+        id: check-image
         run: |
           # Source: https://gist.github.com/webbertakken/1789a4683a99e2a62b975ff436a85382
           function Docker-Tag-Exists {
@@ -130,6 +131,7 @@ jobs:
 
           if (Docker-Tag-Exists -Repository "unityci/base" -Tag "windows-${{ steps.buildParameters.outputs.repoVersionFull }}") {
             echo "Image already exists. Exiting."
+            echo "image_exists=true" >> $Env:GITHUB_OUTPUT
             exit 1
           }
 
@@ -188,7 +190,7 @@ jobs:
           digest: ${{ steps.build_windows_base_image.outputs.digest }}
 
       - name: Report failure
-        if: ${{ failure() || cancelled() }}
+        if: ${{ (failure() || cancelled()) && steps.check-image.outputs.image_exists != 'true' }}
         uses: ./.github/workflows/actions/report-to-backend
         with:
           token: ${{ secrets.VERSIONING_TOKEN }}

--- a/.github/workflows/new-windows-hub-image-requested.yml
+++ b/.github/workflows/new-windows-hub-image-requested.yml
@@ -115,6 +115,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
         run: docker login --username $Env:username --password $Env:password
       - name: Check if image does not already exist
+        id: check-image
         run: |
           # Source: https://gist.github.com/webbertakken/1789a4683a99e2a62b975ff436a85382
           function Docker-Tag-Exists {
@@ -130,6 +131,7 @@ jobs:
 
           if (Docker-Tag-Exists -Repository "unityci/hub" -Tag "windows-${{ steps.buildParameters.outputs.repoVersionFull }}") {
             echo "Image already exists. Exiting."
+            echo "image_exists=true" >> $Env:GITHUB_OUTPUT
             exit 1
           }
 
@@ -194,7 +196,7 @@ jobs:
           digest: ${{ steps.build_windows_hub_image.outputs.digest }}
 
       - name: Report failure
-        if: ${{ failure() || cancelled() }}
+        if: ${{ (failure() || cancelled()) && steps.check-image.outputs.image_exists != 'true' }}
         uses: ./.github/workflows/actions/report-to-backend
         with:
           token: ${{ secrets.VERSIONING_TOKEN }}

--- a/.github/workflows/new-windows-hub-image-requested.yml
+++ b/.github/workflows/new-windows-hub-image-requested.yml
@@ -122,7 +122,7 @@ jobs:
             param([string] $Repository, [string] $Tag)
 
             Try {
-              Invoke-RestMethod "https://index.docker.io/v1/repositories/$Repository/tags/$Tag"
+              Invoke-RestMethod "https://hub.docker.com/v2/repositories/$Repository/tags/$Tag"
             } Catch {} # Assume image does not exist on erroneous response
 
             return $?

--- a/.github/workflows/new-windows-legacy-editor-image-requested.yml
+++ b/.github/workflows/new-windows-legacy-editor-image-requested.yml
@@ -134,6 +134,7 @@ jobs:
         run: docker login --username $Env:username --password $Env:password
 
       - name: Check if image does not already exist
+        id: check-image
         run: |
           # Source: https://gist.github.com/webbertakken/1789a4683a99e2a62b975ff436a85382
           function Docker-Tag-Exists {
@@ -149,6 +150,7 @@ jobs:
 
           if( (Docker-Tag-Exists -Repository unityci/editor -Tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionFull }}) ) {
             echo "Image already exists. Exiting."
+            echo "image_exists=true" >> $Env:GITHUB_OUTPUT
             exit 1
           }
 
@@ -256,7 +258,7 @@ jobs:
           digest: ${{ steps.image-digest.outputs.digest }}
 
       - name: Report failure
-        if: ${{ failure() || cancelled() }}
+        if: ${{ (failure() || cancelled()) && steps.check-image.outputs.image_exists != 'true' }}
         uses: ./.github/workflows/actions/report-to-backend
         with:
           token: ${{ secrets.VERSIONING_TOKEN }}

--- a/.github/workflows/new-windows-legacy-editor-image-requested.yml
+++ b/.github/workflows/new-windows-legacy-editor-image-requested.yml
@@ -141,7 +141,7 @@ jobs:
             param([string] $Repository, [string] $Tag)
 
             Try {
-              Invoke-RestMethod "https://index.docker.io/v1/repositories/$Repository/tags/$Tag"
+              Invoke-RestMethod "https://hub.docker.com/v2/repositories/$Repository/tags/$Tag"
             } Catch {} # Assume image does not exist on erroneous response
 
             return $?

--- a/.github/workflows/new-windows-post-2019-2-editor-image-requested.yml
+++ b/.github/workflows/new-windows-post-2019-2-editor-image-requested.yml
@@ -148,7 +148,7 @@ jobs:
             param([string] $Repository, [string] $Tag)
 
             Try {
-              Invoke-RestMethod "https://index.docker.io/v1/repositories/$Repository/tags/$Tag"
+              Invoke-RestMethod "https://hub.docker.com/v2/repositories/$Repository/tags/$Tag"
             } Catch {} # Assume image does not exist on erroneous response
 
             return $?

--- a/.github/workflows/new-windows-post-2019-2-editor-image-requested.yml
+++ b/.github/workflows/new-windows-post-2019-2-editor-image-requested.yml
@@ -141,6 +141,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
         run: docker login --username $Env:username --password $Env:password
       - name: Check if image does not already exist
+        id: check-image
         run: |
           # Source: https://gist.github.com/webbertakken/1789a4683a99e2a62b975ff436a85382
           function Docker-Tag-Exists {
@@ -156,6 +157,7 @@ jobs:
 
           if( (Docker-Tag-Exists -Repository unityci/editor -Tag windows-${{ steps.buildParameters.outputs.editorVersion }}-${{ matrix.targetPlatform }}-${{ steps.buildParameters.outputs.repoVersionFull }}) ) {
             echo "Image already exists. Exiting."
+            echo "image_exists=true" >> $Env:GITHUB_OUTPUT
             exit 1
           }
 
@@ -263,7 +265,7 @@ jobs:
           digest: ${{ steps.image-digest.outputs.digest }}
 
       - name: Report failure
-        if: ${{ failure() || cancelled() }}
+        if: ${{ (failure() || cancelled()) && steps.check-image.outputs.image_exists != 'true' }}
         uses: ./.github/workflows/actions/report-to-backend
         with:
           token: ${{ secrets.VERSIONING_TOKEN }}

--- a/.github/workflows/retry-ubuntu-editor-image-requested.yml
+++ b/.github/workflows/retry-ubuntu-editor-image-requested.yml
@@ -56,9 +56,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if image does not already exist
         run: |
-          # Source: https://stackoverflow.com/a/39731444/3593896
+          # DockerHub V2 API (V1 was decommissioned, returns 410 Gone)
           function docker_tag_exists() {
-            curl --silent -f -lSL https://index.docker.io/v1/repositories/$1/tags/$2 > /dev/null
+            curl --silent -f -lSL https://hub.docker.com/v2/repositories/$1/tags/$2 > /dev/null
           }
 
           if docker_tag_exists unityci/editor ubuntu-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }} ; then

--- a/.github/workflows/retry-ubuntu-editor-image-requested.yml
+++ b/.github/workflows/retry-ubuntu-editor-image-requested.yml
@@ -55,6 +55,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if image does not already exist
+        id: check-image
         run: |
           # DockerHub V2 API (V1 was decommissioned, returns 410 Gone)
           function docker_tag_exists() {
@@ -63,6 +64,7 @@ jobs:
 
           if docker_tag_exists unityci/editor ubuntu-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }} ; then
             echo "Image already exists. Exiting."
+            echo "image_exists=true" >> $GITHUB_OUTPUT
             exit 1
           fi
       #######################
@@ -163,7 +165,7 @@ jobs:
           specificTag: ubuntu-${{ github.event.client_payload.repoVersionFull }}
           digest: ${{ steps.image-digest.outputs.digest }}
       - name: Report failure
-        if: ${{ failure() || cancelled() }}
+        if: ${{ (failure() || cancelled()) && steps.check-image.outputs.image_exists != 'true' }}
         uses: ./.github/workflows/actions/report-to-backend
         with:
           token: ${{ secrets.VERSIONING_TOKEN }}

--- a/.github/workflows/retry-windows-editor-image-requested.yml
+++ b/.github/workflows/retry-windows-editor-image-requested.yml
@@ -74,6 +74,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
         run: docker login --username $Env:username --password $Env:password
       - name: Check if image does not already exist
+        id: check-image
         run: |
           # Source: https://gist.github.com/webbertakken/1789a4683a99e2a62b975ff436a85382
           function Docker-Tag-Exists {
@@ -89,6 +90,7 @@ jobs:
 
           if( (Docker-Tag-Exists -Repository unityci/editor -Tag windows-${{ github.event.client_payload.editorVersion }}-${{ github.event.client_payload.targetPlatform }}-${{ github.event.client_payload.repoVersionFull }}) ) {
             echo "Image already exists. Exiting."
+            echo "image_exists=true" >> $Env:GITHUB_OUTPUT
             exit 1
           }
 
@@ -195,7 +197,7 @@ jobs:
           digest: ${{ steps.image-digest.outputs.digest }}
 
       - name: Report failure
-        if: ${{ failure() || cancelled() }}
+        if: ${{ (failure() || cancelled()) && steps.check-image.outputs.image_exists != 'true' }}
         uses: ./.github/workflows/actions/report-to-backend
         with:
           token: ${{ secrets.VERSIONING_TOKEN }}

--- a/.github/workflows/retry-windows-editor-image-requested.yml
+++ b/.github/workflows/retry-windows-editor-image-requested.yml
@@ -81,7 +81,7 @@ jobs:
             param([string] $Repository, [string] $Tag)
 
             Try {
-              Invoke-RestMethod "https://index.docker.io/v1/repositories/$Repository/tags/$Tag"
+              Invoke-RestMethod "https://hub.docker.com/v2/repositories/$Repository/tags/$Tag"
             } Catch {} # Assume image does not exist on erroneous response
 
             return $?


### PR DESCRIPTION
## Summary

Follow-up to #281 (V1→V2 DockerHub tag check migration).

The V2 tag check now correctly detects existing images, but `exit 1` triggers the "Report failure" step, which **marks already-published builds as failed in Firestore**. This causes the Ingeminator to needlessly retry them in an infinite cycle.

## What was happening

1. Retry workflow starts for an already-published build
2. "Report started" → backend returns 409 (duplicate, already published) → exits gracefully
3. V2 tag check detects image exists → `exit 1`
4. "Report failure" step runs (because `failure()` is true) → **marks build as failed in Firestore**
5. Ingeminator sees failed build → retries → cycle repeats

## Fix

- Add `id: check-image` to the tag check step
- Set `image_exists=true` output before `exit 1`
- Exclude image-exists cases from the Report failure condition:
  ```yaml
  if: ${{ (failure() || cancelled()) && steps.check-image.outputs.image_exists != 'true' }}
  ```

All 10 workflow files updated (same 10 as #281).

## Test plan

- [ ] After merge, verify retry builds for existing images no longer report failure to backend
- [ ] Verify retry builds for genuinely missing images still report failure correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated container image build workflows to use current Docker API standards and improved handling of existing images for more reliable continuous integration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->