### PR TITLE
fix: add missing ${{ }} expression syntax in Windows Hub workflow

### DIFF
--- a/.github/workflows/new-windows-hub-image-requested.yml
+++ b/.github/workflows/new-windows-hub-image-requested.yml
@@ -51,10 +51,10 @@ jobs:
           if ("${{ github.event.inputs.jobId }}")
           {
             # Workflow Dispatch
-            echo "jobId={{ github.event.inputs.jobId }}" >> $Env:GITHUB_OUTPUT
-            echo "repoVersionFull={{ github.event.inputs.repoVersionFull }}" >> $Env:GITHUB_OUTPUT
-            echo "repoVersionMinor={{ github.event.inputs.repoVersionMinor }}" >> $Env:GITHUB_OUTPUT
-            echo "repoVersionMajor={{ github.event.inputs.repoVersionMajor }}" >> $Env:GITHUB_OUTPUT
+            echo "jobId=${{ github.event.inputs.jobId }}" >> $Env:GITHUB_OUTPUT
+            echo "repoVersionFull=${{ github.event.inputs.repoVersionFull }}" >> $Env:GITHUB_OUTPUT
+            echo "repoVersionMinor=${{ github.event.inputs.repoVersionMinor }}" >> $Env:GITHUB_OUTPUT
+            echo "repoVersionMajor=${{ github.event.inputs.repoVersionMajor }}" >> $Env:GITHUB_OUTPUT
           } else
           {
             # Repo Dispatch


### PR DESCRIPTION
## Summary

- Fixes missing `${{ }}` expression wrappers in the `workflow_dispatch` branch of `new-windows-hub-image-requested.yml`
- The Setup Build Parameters step was outputting literal strings like `{{ github.event.inputs.jobId }}` instead of evaluating them as GitHub Actions expressions
- This broke manual workflow_dispatch triggers — jobId and repoVersion values were all literal text instead of actual input values

## What changed

4 lines in the workflow_dispatch branch — added the missing `$` prefix to expression syntax:
```diff
- echo "jobId={{ github.event.inputs.jobId }}" >> $Env:GITHUB_OUTPUT
+ echo "jobId=${{ github.event.inputs.jobId }}" >> $Env:GITHUB_OUTPUT
```

The `repository_dispatch` branch (line 61-64) was already correct.

## Test plan

- [ ] Trigger a manual `workflow_dispatch` on the Windows Hub workflow with a test `jobId` and verify the outputs resolve correctly in the "Show hook input" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed manual workflow input value handling to ensure downstream automation steps receive the intended configuration values, improving reliability of automated processes triggered through the GitHub interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->