### PR TITLE
fix: skip duplicate server module installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,6 +191,25 @@ jobs:
       #   Setup   #
       #############
       - uses: actions/checkout@v5
+      - name: Start Docker
+        shell: pwsh
+        run: |
+          $service = Get-Service -Name docker -ErrorAction Stop
+          if ($service.Status -ne 'Running') {
+            Start-Service -Name docker
+          }
+
+          $deadline = (Get-Date).AddMinutes(2)
+          while ((Get-Date) -lt $deadline) {
+            try {
+              docker version
+              exit 0
+            } catch {
+              Start-Sleep -Seconds 5
+            }
+          }
+
+          throw 'Docker daemon did not become ready in time.'
 
       ##################################
       #   Build Windows base and hub   #

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -10,7 +10,11 @@ FROM $hubImage AS builder
 # Install editor
 ARG version
 ARG changeSet
-RUN unity-hub install --version "$version" --changeset "$changeSet" | tee /var/log/install-editor.log && grep 'Failed to install\|Error while installing an editor\|Completed with errors' /var/log/install-editor.log | exit $(wc -l)
+RUN unity-hub install --version "$version" --changeset "$changeSet" > /var/log/install-editor.log 2>&1 \
+  && cat /var/log/install-editor.log \
+  && ! grep -Eq 'Failed to install|Error while installing an editor|Completed with errors' /var/log/install-editor.log \
+  && test -d "/opt/unity/editors/$version/Editor" \
+  && test -f "/opt/unity/editors/$version/modules.json"
 
 # Install modules for that editor
 ARG module="non-existent-module"
@@ -18,7 +22,9 @@ RUN for mod in $module; do \
       if [ "$mod" = "base" ] ; then \
         echo "running default modules for this baseOs"; \
       else \
-        unity-hub install-modules --version "$version" --module "$mod" --childModules | tee /var/log/install-module-${mod}.log && grep 'Missing module\|Completed with errors' /var/log/install-module-${mod}.log | exit $(wc -l); \
+        unity-hub install-modules --version "$version" --module "$mod" --childModules > /var/log/install-module-${mod}.log 2>&1; \
+        cat /var/log/install-module-${mod}.log; \
+        ! grep -Eq 'Missing module|Completed with errors|Failed to execute the command due the following|^Error:' /var/log/install-module-${mod}.log; \
       fi \
     done \
 	# Set execute permissions for modules
@@ -31,7 +37,9 @@ RUN if ! echo "$version-$module" | grep -qP '^(2021.2.(?![0-4](?![0-9]))|2021.[3
       echo "linux-server already selected; skipping auto-install"; \
       exit 0; \
     fi; \
-    unity-hub install-modules --version "$version" --module "linux-server" --childModules | tee /var/log/install-module-linux-server.log && grep 'Missing module' /var/log/install-module-linux-server.log | exit $(wc -l);
+    unity-hub install-modules --version "$version" --module "linux-server" --childModules > /var/log/install-module-linux-server.log 2>&1; \
+    cat /var/log/install-module-linux-server.log; \
+    ! grep -Eq 'Missing module|Completed with errors|Failed to execute the command due the following|^Error:' /var/log/install-module-linux-server.log;
 
 RUN if ! echo "$version-$module" | grep -qP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|[6-9][0-9]{3}|[1-9][0-9]{4,}).*windows'; then \
       exit 0; \
@@ -40,7 +48,9 @@ RUN if ! echo "$version-$module" | grep -qP '^(2021.2.(?![0-4](?![0-9]))|2021.[3
       echo "windows-server already selected; skipping auto-install"; \
       exit 0; \
     fi; \
-    unity-hub install-modules --version "$version" --module "windows-server" --childModules | tee /var/log/install-module-windows-server.log && grep 'Missing module' /var/log/install-module-windows-server.log | exit $(wc -l);
+    unity-hub install-modules --version "$version" --module "windows-server" --childModules > /var/log/install-module-windows-server.log 2>&1; \
+    cat /var/log/install-module-windows-server.log; \
+    ! grep -Eq 'Missing module|Completed with errors|Failed to execute the command due the following|^Error:' /var/log/install-module-windows-server.log;
 
 ###########################
 #          Editor         #

--- a/images/ubuntu/editor/Dockerfile
+++ b/images/ubuntu/editor/Dockerfile
@@ -24,13 +24,23 @@ RUN for mod in $module; do \
 	# Set execute permissions for modules
 	&& chmod -R 755 /opt/unity/editors/$version/Editor/Data/PlaybackEngines
 
-RUN echo "$version-$module" | grep -q -vP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|[6-9][0-9]{3}|[1-9][0-9]{4,}).*linux' \
-  && exit 0 \
-  || unity-hub install-modules --version "$version" --module "linux-server" --childModules | tee /var/log/install-module-linux-server.log && grep 'Missing module' /var/log/install-module-linux-server.log | exit $(wc -l);
+RUN if ! echo "$version-$module" | grep -qP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|[6-9][0-9]{3}|[1-9][0-9]{4,}).*linux'; then \
+      exit 0; \
+    fi; \
+    if grep -q '"id"[[:space:]]*:[[:space:]]*"linux-server"' "/opt/unity/editors/$version/modules.json"; then \
+      echo "linux-server already selected; skipping auto-install"; \
+      exit 0; \
+    fi; \
+    unity-hub install-modules --version "$version" --module "linux-server" --childModules | tee /var/log/install-module-linux-server.log && grep 'Missing module' /var/log/install-module-linux-server.log | exit $(wc -l);
 
-RUN echo "$version-$module" | grep -q -vP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|[6-9][0-9]{3}|[1-9][0-9]{4,}).*windows' \
-  && exit 0 \
-  || unity-hub install-modules --version "$version" --module "windows-server" --childModules | tee /var/log/install-module-windows-server.log && grep 'Missing module' /var/log/install-module-windows-server.log | exit $(wc -l);
+RUN if ! echo "$version-$module" | grep -qP '^(2021.2.(?![0-4](?![0-9]))|2021.[3-9]|202[2-9]|[6-9][0-9]{3}|[1-9][0-9]{4,}).*windows'; then \
+      exit 0; \
+    fi; \
+    if grep -q '"id"[[:space:]]*:[[:space:]]*"windows-server"' "/opt/unity/editors/$version/modules.json"; then \
+      echo "windows-server already selected; skipping auto-install"; \
+      exit 0; \
+    fi; \
+    unity-hub install-modules --version "$version" --module "windows-server" --childModules | tee /var/log/install-module-windows-server.log && grep 'Missing module' /var/log/install-module-windows-server.log | exit $(wc -l);
 
 ###########################
 #          Editor         #

--- a/images/windows/hub/Dockerfile
+++ b/images/windows/hub/Dockerfile
@@ -3,4 +3,9 @@ ARG baseImage="unityci/base:windows-latest"
 FROM $baseImage
 
 # Install unity hub
-RUN choco install unity-hub --no-progress -y
+RUN powershell -Command `
+  $ErrorActionPreference = 'Stop'; `
+  $installer = 'C:\UnityHubSetup-x64.exe'; `
+  Invoke-WebRequest -Uri 'https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup-x64.exe' -OutFile $installer; `
+  Start-Process -FilePath $installer -ArgumentList '/S' -Wait; `
+  Remove-Item $installer -Force

--- a/images/windows/hub/Dockerfile
+++ b/images/windows/hub/Dockerfile
@@ -1,3 +1,4 @@
+# escape=`
 ARG baseImage="unityci/base:windows-latest"
 
 FROM $baseImage


### PR DESCRIPTION
## Summary
- skip auto-installing linux-server/windows-server when Unity Hub already selected them via child modules
- prevents Unity Hub failures like 'module windows-server is already selected in modules.json'

## Verification
- not run: Docker template-only change